### PR TITLE
New scheduling algorithm

### DIFF
--- a/orchestra/__main__.py
+++ b/orchestra/__main__.py
@@ -3,4 +3,5 @@
 from . import main
 
 if __name__ == "__main__":
-    main()
+    return_value = main() or 0
+    exit(return_value)

--- a/orchestra/actions/__init__.py
+++ b/orchestra/actions/__init__.py
@@ -1,4 +1,4 @@
 from .clone import CloneAction
 from .configure import ConfigureAction
 from .install import InstallAction
-from .install import InstallAnyBuildAction
+from .any_of import AnyOfAction

--- a/orchestra/actions/any_of.py
+++ b/orchestra/actions/any_of.py
@@ -1,0 +1,31 @@
+class AnyOfAction:
+    # Used to assign a unique number so that when printing a graph
+    # the node does not get aliased
+    INSTANCE_COUNTER = 1
+
+    def __init__(self, actions, preferred_action):
+        self.actions = actions
+        self.preferred_action = preferred_action
+        self.unique_number = AnyOfAction.INSTANCE_COUNTER
+        AnyOfAction.INSTANCE_COUNTER += 1
+
+    def add_explicit_dependency(self, dependency):
+        for action in self.actions:
+            action.add_explicit_dependency(dependency)
+
+    @property
+    def dependencies(self):
+        return {a for a in self.actions}
+
+    def is_satisfied(self):
+        return any(d.is_satisfied() for d in self.dependencies)
+
+    @property
+    def name_for_components(self):
+        return f"Any of {{{', '.join(a.name_for_components for a in self.actions)}}}"
+
+    def __str__(self):
+        return f"AnyOf [{self.unique_number}]"
+
+    def __repr__(self):
+        return f"AnyOf [{self.unique_number}]"

--- a/orchestra/actions/clone.py
+++ b/orchestra/actions/clone.py
@@ -32,7 +32,7 @@ class CloneAction(ActionForComponent):
         """Executes the action"""
         run_script(self.script, quiet=True, environment=self.environment)
 
-    def _is_satisfied(self):
+    def is_satisfied(self):
         return os.path.exists(self.environment["SOURCE_DIR"])
 
     def branches(self):

--- a/orchestra/actions/configure.py
+++ b/orchestra/actions/configure.py
@@ -10,7 +10,8 @@ class ConfigureAction(ActionForBuild):
     def __init__(self, build, script, config):
         super().__init__("configure", build, script, config)
 
-    def _is_satisfied(self):
+    def is_satisfied(self):
+        # TODO: invalidate configure if self_hash (or even recursive_hash?) has changed
         return os.path.exists(self._configure_successful_path)
 
     def _run(self, args):

--- a/orchestra/actions/graph_util.py
+++ b/orchestra/actions/graph_util.py
@@ -1,0 +1,30 @@
+import networkx as nx
+
+from .any_of import AnyOfAction
+from .action import Action
+
+
+def assign_style(graph):
+    styles = {}
+    for node in graph.nodes:
+        if isinstance(node, AnyOfAction):
+            color = "lightblue"
+        elif isinstance(node, Action) and node.is_satisfied():
+            color = "green"
+        else:
+            color = "white"
+        styles[node] = {
+            "shape": "box",
+            "style": "filled",
+            "fillcolor": color,
+        }
+    nx.set_node_attributes(graph, styles)
+
+
+def show_graph(graph):
+    """
+    Debugging utility to dump a graph
+    """
+    assign_style(graph)
+    fname = "/tmp/graph.svg"
+    nx.nx_agraph.view_pygraphviz(graph, path=fname, show=False, args="-Gsplines=ortho")

--- a/orchestra/actions/uninstall.py
+++ b/orchestra/actions/uninstall.py
@@ -1,0 +1,52 @@
+import os
+
+from loguru import logger
+
+
+def uninstall(component_name, config):
+    index_path = config.installed_component_file_list_path(component_name)
+    metadata_path = config.installed_component_metadata_path(component_name)
+
+    # Index and metadata files should be removed last,
+    # so an interrupted uninstall can be resumed
+    postpone_removal_paths = [
+        os.path.relpath(index_path, config.orchestra_root),
+        os.path.relpath(metadata_path, config.orchestra_root)
+    ]
+
+    with open(index_path) as f:
+        paths = f.readlines()
+
+    # Ensure depth first visit by reverse-sorting
+    # paths.sort(reverse=True)
+    paths = [path.strip() for path in paths]
+
+    for path in paths:
+        # Ensure the path is relative to the root
+        path = path.lstrip("/")
+
+        if path in postpone_removal_paths:
+            continue
+
+        path_to_delete = os.path.join(config.global_env()['ORCHESTRA_ROOT'], path)
+
+        if os.path.isfile(path_to_delete) or os.path.islink(path_to_delete):
+            logger.debug(f"Deleting {path_to_delete}")
+            os.remove(path_to_delete)
+        elif os.path.isdir(path_to_delete):
+            if os.listdir(path_to_delete):
+                logger.debug(f"Not removing directory {path_to_delete} as it is not empty")
+            else:
+                logger.debug(f"Deleting directory {path_to_delete}")
+                os.rmdir(path_to_delete)
+
+        containing_directory = os.path.dirname(path_to_delete)
+        if os.path.exists(containing_directory) and len(os.listdir(containing_directory)) == 0:
+            logger.debug(f"Removing empty directory {containing_directory}")
+            os.rmdir(containing_directory)
+
+    logger.debug(f"Deleting index file {index_path}")
+    os.remove(index_path)
+
+    logger.debug(f"Deleting metadata file {metadata_path}")
+    os.remove(metadata_path)

--- a/orchestra/cmds/clean.py
+++ b/orchestra/cmds/clean.py
@@ -23,7 +23,7 @@ def handle_clean(args):
     if not build:
         suggested_component_name = config.get_suggested_component_name(args.component)
         logger.error(f"Component {args.component} not found! Did you mean {suggested_component_name}?")
-        exit(1)
+        return 1
 
     build_dir = build.install.environment["BUILD_DIR"]
     logger.info(f"Cleaning build dir for {build.qualified_name} ({build_dir})")

--- a/orchestra/cmds/clone.py
+++ b/orchestra/cmds/clone.py
@@ -12,7 +12,6 @@ def install_subcommand(sub_argparser):
                                           parents=[execution_options],
                                           )
     cmd_parser.add_argument("component", help="Name of the component to clone")
-    cmd_parser.add_argument("--no-force", action="store_true", help="Don't force execution of the root action")
 
 
 def handle_clone(args):
@@ -22,10 +21,13 @@ def handle_clone(args):
     if not build:
         suggested_component_name = config.get_suggested_component_name(args.component)
         logger.error(f"Component {args.component} not found! Did you mean {suggested_component_name}?")
-        exit(1)
+        return 1
 
     if not build.component.clone:
         print("This component does not have a git repository configured!")
-        return
-    executor = Executor(args)
-    return executor.run(build.component.clone, no_force=args.no_force)
+        return 1
+
+    executor = Executor(args, [build.clone])
+    failed = executor.run()
+    exitcode = 1 if failed else 0
+    return exitcode

--- a/orchestra/cmds/configure.py
+++ b/orchestra/cmds/configure.py
@@ -26,7 +26,9 @@ def handle_configure(args):
     if not build:
         suggested_component_name = config.get_suggested_component_name(args.component)
         logger.error(f"Component {args.component} not found! Did you mean {suggested_component_name}?")
-        exit(1)
+        return 1
 
-    executor = Executor(args)
-    return executor.run(build.configure, no_force=args.no_force, no_deps=args.no_deps)
+    executor = Executor(args, [build.configure], no_deps=args.no_deps)
+    failed = executor.run()
+    exitcode = 1 if failed else 0
+    return exitcode

--- a/orchestra/cmds/dumpconfig.py
+++ b/orchestra/cmds/dumpconfig.py
@@ -2,7 +2,7 @@ from ..model.configuration import Configuration
 
 
 def install_subcommand(sub_argparser):
-    cmd_parser = sub_argparser.add_parser("dumpconfig", handler=handle_dumpconfig, help="Dump yaml configuration")
+    sub_argparser.add_parser("dumpconfig", handler=handle_dumpconfig, help="Dump yaml configuration")
 
 
 def handle_dumpconfig(args):

--- a/orchestra/cmds/environment.py
+++ b/orchestra/cmds/environment.py
@@ -19,6 +19,6 @@ def handle_environment(args):
         if not build:
             suggested_component_name = config.get_suggested_component_name(args.component)
             logger.error(f"Component {args.component} not found! Did you mean {suggested_component_name}?")
-            exit(1)
+            return 1
 
         print(export_environment(build.install.environment))

--- a/orchestra/cmds/graph.py
+++ b/orchestra/cmds/graph.py
@@ -1,6 +1,8 @@
+import networkx as nx
 from loguru import logger
 
 from .common import build_options
+from ..executor import Executor
 from ..model.configuration import Configuration
 
 
@@ -12,7 +14,19 @@ def install_subcommand(sub_argparser):
                                           )
     cmd_parser.add_argument("component", nargs="?")
     cmd_parser.add_argument("--all-builds", action="store_true",
-                            help="Include all builds instead of only the default one.")
+                            help="Include all builds instead of only the default one.\n"
+                                 "Can't be used with --solved")
+
+    cmd_parser.add_argument("--solved", "-s", action="store_true",
+                            help="Print the solved dependency graph that would be used to schedule actions")
+    cmd_parser.add_argument("--no-remove-unreachable", action="store_true",
+                            help="Don't remove unreachable actions")
+    cmd_parser.add_argument("--no-simplify-anyof", action="store_true",
+                            help="Don't remove choices")
+    cmd_parser.add_argument("--no-remove-satisfied-leaves", action="store_true",
+                            help="Don't remove satisfied leaves")
+    cmd_parser.add_argument("--no-transitive-reduction", action="store_true",
+                            help="Don't perform transitive reduction")
 
 
 def handle_graph(args):
@@ -26,7 +40,7 @@ def handle_graph(args):
         if not build:
             suggested_component_name = config.get_suggested_component_name(args.component)
             logger.error(f"Component {args.component} not found! Did you mean {suggested_component_name}?")
-            exit(1)
+            return 1
 
         actions = [build.install]
     else:
@@ -38,38 +52,18 @@ def handle_graph(args):
             else:
                 actions.add(component.default_build.install)
 
-    print("digraph dependency_graph {")
-    print("  splines=ortho")
-    print_dependencies(actions)
-    print("}")
+    executor = Executor(args, actions)
 
-
-def print_dependencies(actions):
-    # TODO: this code needs to deduplicate rows and handle potential dependency cycles
-    #  It is ugly and should be improved
-    def _print_dependencies(action, already_visited_actions, rows):
-        if action in already_visited_actions:
-            return
-
-        if action.is_satisfied(recursively=True):
-            color = "green"
-        elif action.can_run():
-            color = "orange"
-        else:
-            color = "red"
-
-        rows.add(f'  "{action.name_for_graph}"[ shape=box, style=filled, color={color} ];')
-        for d in action.dependencies:
-            rows.add(f'  "{d.name_for_graph}" -> "{action.name_for_graph}";')
-
-        already_visited_actions.add(action)
-
-        for d in action.dependencies:
-            _print_dependencies(d, already_visited_actions, rows)
-
-    already_visited_actions = set()
-    rows = set()
-    for action in actions:
-        _print_dependencies(action, already_visited_actions, rows)
-    for r in sorted(rows):
-        print(r)
+    if not args.solved:
+        graph = executor._create_initial_dependency_graph()
+    else:
+        graph = executor._create_dependency_graph(
+            remove_unreachable=not args.no_remove_unreachable,
+            simplify_anyof=not args.no_simplify_anyof,
+            remove_satisfied=not args.no_remove_satisfied_leaves,
+            transitive_reduction=not args.no_transitive_reduction
+        )
+    graphviz_format = nx.nx_agraph.to_agraph(graph)
+    graphviz_format.graph_attr["splines"] = "ortho"
+    graphviz_format.node_attr["shape"] = "box"
+    print(graphviz_format)

--- a/orchestra/cmds/install.py
+++ b/orchestra/cmds/install.py
@@ -13,7 +13,6 @@ def install_subcommand(sub_argparser):
                                           )
     cmd_parser.add_argument("component", help="Name of the component to install")
     cmd_parser.add_argument("--no-deps", action="store_true", help="Only execute the requested action")
-    cmd_parser.add_argument("--no-force", action="store_true", help="Don't force execution of the root action")
     cmd_parser.add_argument("--no-merge", action="store_true", help="Do not merge files into orchestra root")
     cmd_parser.add_argument("--create-binary-archives", action="store_true", help="Create binary archives")
     cmd_parser.add_argument("--keep-tmproot", action="store_true", help="Do not remove temporary root directories")
@@ -30,7 +29,9 @@ def handle_install(args):
     if not build:
         suggested_component_name = config.get_suggested_component_name(args.component)
         logger.error(f"Component {args.component} not found! Did you mean {suggested_component_name}?")
-        exit(1)
+        return 1
 
-    executor = Executor(args)
-    return executor.run(build.install, no_force=args.no_force, no_deps=args.no_deps)
+    executor = Executor(args, [build.install], no_deps=args.no_deps)
+    failed = executor.run()
+    exitcode = 1 if failed else 0
+    return exitcode

--- a/orchestra/cmds/ls.py
+++ b/orchestra/cmds/ls.py
@@ -18,7 +18,7 @@ def handle_ls(args):
 
     if args.git_sources + args.binary_archives != 1:
         logger.error("Please specify one and one flag only")
-        exit(1)
+        return 1
 
     if args.git_sources:
         for component in config.components.values():

--- a/orchestra/cmds/shell.py
+++ b/orchestra/cmds/shell.py
@@ -32,7 +32,7 @@ def handle_shell(args):
         if not build:
             suggested_component_name = config.get_suggested_component_name(args.component)
             logger.error(f"Component {args.component} not found! Did you mean {suggested_component_name}?")
-            exit(1)
+            return 1
 
         env = build.install.environment
         ps1_prefix = f"(orchestra - {build.qualified_name}) "

--- a/orchestra/cmds/uninstall.py
+++ b/orchestra/cmds/uninstall.py
@@ -15,6 +15,6 @@ def handle_uninstall(args):
     component_name, build_name = parse_component_name(args.component)
     if not is_installed(config, component_name, build_name):
         logger.error(f"Component {args.component} is not installed")
-        exit(1)
+        return 1
 
     uninstall(component_name, config)

--- a/orchestra/executor.py
+++ b/orchestra/executor.py
@@ -1,109 +1,378 @@
 from concurrent import futures
 from typing import List, Dict
-import enlighten
 
+import enlighten
+import graphlib
+import networkx as nx
+import networkx.classes.filters as nxfilters
+import threading
+import time
 from loguru import logger
 
+from .actions import AnyOfAction
 from .actions.action import Action
 from .util import set_terminal_title, OrchestraException
 
 
 class Executor:
-    def __init__(self, args, threads=1):
+    def __init__(self, args, actions, no_deps=False, threads=1):
         self.args = args
+        self.actions = actions
+        self.no_deps = no_deps
         self.threads = 1
-        self._pending_actions: List[Action] = []
-        self._running_actions: Dict[futures.Future, Action] = {}
-        self._failed_actions: List[Action] = []
+
+        self._toposorter = graphlib.TopologicalSorter()
         self._pool = futures.ThreadPoolExecutor(max_workers=threads, thread_name_prefix="Builder")
+        self._queued_actions: Dict[futures.Future, Action] = {}
+        self._running_actions: List[Action] = []
+        self._failed_actions: List[Action] = []
 
-    def run(self, action, no_force=False, no_deps=False):
-        self._collect_actions(action, force=not no_force, no_deps=no_deps)
-        self._pending_actions.sort(key=lambda a: a.qualified_name)
+        self._total_remaining = None
+        self._current_remaining = None
+        self._stop_updating_display = False
+        self._display_manager: enlighten.Manager
+        self._display_thread: threading.Thread
 
-        if not self._pending_actions:
+    def run(self):
+        dependency_graph = self._create_dependency_graph()
+
+        self._init_toposorter(dependency_graph)
+
+        try:
+            self._toposorter.prepare()
+        except graphlib.CycleError as e:
+            # TODO: replace with OrchestraException from Ale fork when merging
+            raise Exception(f"A cycle was found in the dependency graph: {e.args[1]}. This should never happen.")
+
+        if not self._toposorter.is_active():
             logger.info("No actions to perform")
 
-        total_pending = len(self._pending_actions)
+        self._total_remaining = dependency_graph.number_of_nodes()
+        self._current_remaining = self._total_remaining
 
-        for _ in range(self.threads):
-            self._schedule_next()
+        self._start_display_update()
 
-        manager = enlighten.get_manager()
-        status_bar = manager.status_bar()
-        status_bar.color = "bright_white_on_lightslategray"
+        # Schedule and run the actions
+        while self._toposorter.is_active() and not self._failed_actions:
+            for action in self._toposorter.get_ready():
+                future = self._pool.submit(self._run_action, action)
+                self._queued_actions[future] = action
 
-        while self._running_actions:
-            running_jobs_str = ", ".join(a.name_for_info for a in self._running_actions.values())
-            status_bar_args = {
-                "jobs": running_jobs_str,
-                "current": total_pending - len(self._pending_actions),
-                "total": total_pending,
-            }
-            set_terminal_title(f"Running {running_jobs_str}")
-            status_bar.status_format = "[{current}/{total}] Running {jobs}"
-            status_bar.update(**status_bar_args)
-            status_bar.refresh()
-
-            done, not_done = futures.wait(self._running_actions, return_when=futures.FIRST_COMPLETED)
-            for d in done:
-                action = self._running_actions[d]
-                del self._running_actions[d]
-                exception = d.exception()
+            done, not_done = futures.wait(self._queued_actions, return_when=futures.FIRST_COMPLETED)
+            for completed_future in done:
+                action = self._queued_actions[completed_future]
+                del self._queued_actions[completed_future]
+                exception = completed_future.exception()
                 if exception:
                     if isinstance(exception, OrchestraException):
                         logger.error(str(exception))
-                        if self._pending_actions:
-                            logger.error(f"Waiting for other running actions to terminate: {self._pending_actions}")
-                            self._pending_actions = []
+                        logger.error(f"Waiting for other running actions to terminate")
+                        self._pool.shutdown(wait=True)
                         self._failed_actions.append(action)
                     else:
                         raise exception
                 else:
-                    self._schedule_next()
+                    self._toposorter.done(action)
 
-        if self._failed_actions:
-            msg = "Failed: " + ", ".join(a.name_for_info for a in self._failed_actions)
-            status_bar.color = "white_on_red"
-            result = 1
-        else:
-            msg = "All done!"
-            status_bar.color = "white_on_darkgreen"
-            result = 0
+        # Wait for pending actions to finish
+        done, not_done = futures.wait(self._queued_actions, return_when=futures.ALL_COMPLETED)
+        for completed_future in done:
+            action = self._queued_actions[completed_future]
+            del self._queued_actions[completed_future]
+            exception = completed_future.exception()
+            if exception:
+                if isinstance(exception, OrchestraException):
+                    logger.error(str(exception))
+                    logger.error(f"Waiting for other running actions to terminate")
+                    self._pool.shutdown(wait=True)
+                    self._failed_actions.append(action)
+                else:
+                    raise exception
+            else:
+                self._toposorter.done(action)
 
-        status_bar.status_format = msg
-        status_bar.close()
-        return result
+        self._stop_display_update()
 
-    def _collect_actions(self, action: Action, force=False, no_deps=False):
-        if not force and action.is_satisfied(recursively=True):
+        return list(self._failed_actions)
+
+    def _create_dependency_graph(self,
+                                 remove_unreachable=True,
+                                 simplify_anyof=True,
+                                 remove_satisfied=True,
+                                 transitive_reduction=True,
+                                 ):
+        # Recursively collect all dependencies of the root action in an initial graph
+        dependency_graph = self._create_initial_dependency_graph()
+
+        # Find an assignment for all the choices so the graph becomes acyclic
+        dependency_graph = self._assign_choices(dependency_graph)
+        if dependency_graph is None:
+            # TODO: replace with OrchestraException from Ale fork when merging
+            raise Exception("Could not find an acyclic assignment for the given dependency graph")
+
+        if remove_unreachable:
+            self._remove_unreachable_actions(dependency_graph, ["Dummy root"])
+
+        if simplify_anyof:
+            # The graph returned contains choices with only one alternative
+            # Simplify them by turning A -> Choice -> B into A -> B
+            self._simplify_anyof_actions(dependency_graph)
+
+        # Remove the dummy root node
+        true_roots = list(dependency_graph.successors("Dummy root"))
+        dependency_graph.remove_node("Dummy root")
+        if remove_satisfied:
+            self._remove_satisfied_attracting_components(dependency_graph)
+            # Re-add the true root actions as they may have been removed
+            dependency_graph.add_nodes_from(true_roots)
+
+        if transitive_reduction:
+            dependency_graph = self._transitive_reduction(dependency_graph)
+
+        return dependency_graph
+
+    def _create_initial_dependency_graph(self):
+        graph = nx.DiGraph()
+        for action in self.actions:
+            graph.add_edge("Dummy root", action)
+            self._collect_dependencies(action, graph)
+        return graph
+
+    def _collect_dependencies(self, action, graph, already_visited_nodes=None):
+        if already_visited_nodes is None:
+            already_visited_nodes = set()
+
+        if action in already_visited_nodes:
             return
 
-        if action not in self._pending_actions:
-            self._pending_actions.append(action)
-            if no_deps:
-                return
-
-            for dep in action.dependencies:
-                self._collect_actions(dep)
-
-    def _schedule_next(self):
-        next_runnable_action = self._get_next_runnable_action()
-        if not next_runnable_action:
-            if self._pending_actions:
-                logger.error(f"Could not run any action! An action has failed or there is a circular dependency")
-                self._failed_actions = list(self._pending_actions)
+        already_visited_nodes.add(action)
+        graph.add_node(action)
+        if self.no_deps:
             return
 
-        future = self._pool.submit(self._run_action, next_runnable_action)
-        self._running_actions[future] = next_runnable_action
-        return future
+        for dependency in action.dependencies:
+            graph.add_edge(action, dependency)
+            self._collect_dependencies(
+                dependency,
+                graph,
+                already_visited_nodes=already_visited_nodes
+            )
 
-    def _get_next_runnable_action(self):
-        for action in self._pending_actions:
-            if all([d.is_satisfied(recursively=True) for d in action.dependencies]):
-                self._pending_actions.remove(action)
-                return action
+    def _assign_choices(self, graph):
+        # We can assign the choices for each strongly connected component independently
+        while has_choices(graph):
+            strongly_connected_components = list(nx.algorithms.strongly_connected_components(graph))
+            strongly_connected_components.sort(key=len, reverse=True)
+            for strongly_connected_component in strongly_connected_components:
+                any_of_nodes = [
+                    c for c in strongly_connected_component
+                    if isinstance(c, AnyOfAction) and len(list(graph.successors(c))) > 1
+                ]
+                if not any_of_nodes:
+                    # There are no InstallAny nodes in this SCC, don't waste time
+                    continue
+                graph = self._assign_strongly_connected_component(graph, any_of_nodes, strongly_connected_component)
+                if graph is None:
+                    return graph
+                break
+
+        return graph
+
+    def _assign_strongly_connected_component(self, graph, remaining, strongly_connected_component):
+        # TODO: the copy() operation ~halves performance.
+        #  The other edge/node add/removal operations have an impact as well.
+        #  We can avoid them using filtered views
+
+        # No more choices remain, check if the subgraph
+        # of the stringly connected components is cyclic
+        if not remaining:
+            subgraph = graph.copy()
+            self._remove_unreachable_actions(subgraph, ["Dummy root"])
+            subgraph = subgraph.subgraph(strongly_connected_component)
+
+            if has_unsatisfied_cycles(subgraph):
+                return None
+            else:
+                return graph
+
+        to_assign = remaining.pop()
+
+        # Try all choices
+        alternatives = list(graph.successors(to_assign))
+        alternatives.sort(key=keyer(to_assign))
+
+        graph.remove_edges_from((to_assign, s) for s in alternatives)
+
+        for alternative in alternatives:
+            graph.add_edge(to_assign, alternative)
+
+            #  Assigning nodes that are not reachable from the root is pointless
+            _, pointless = filter_out_unreachable(graph, remaining, ["Dummy root"])
+            for n in pointless:
+                remaining.remove(n)
+
+            solved_graph = self._assign_strongly_connected_component(graph, remaining, strongly_connected_component)
+            if solved_graph is None:
+                graph.remove_edge(to_assign, alternative)
+
+                for n in pointless:
+                    remaining.append(n)
+            else:
+                return solved_graph
+
+        graph.add_edges_from((to_assign, a) for a in alternatives)
+        remaining.append(to_assign)
+
+    @staticmethod
+    def _simplify_anyof_actions(graph):
+        for action in list(graph.nodes):
+            if isinstance(action, AnyOfAction):
+                predecessors = list(graph.predecessors(action))
+                successors = list(graph.successors(action))
+                assert len(successors) == 1, f"Choice {action} was not taken?"
+                graph.remove_node(action)
+                graph.add_edges_from((p, successors[0]) for p in predecessors)
+
+    @staticmethod
+    def _remove_unreachable_actions(graph, roots):
+        # Remove all nodes that are not reachable from one of the roots
+        shortest_paths = nx.multi_source_dijkstra_path_length(graph, roots)
+        for node in list(graph.nodes):
+            if node not in shortest_paths:
+                graph.remove_node(node)
+
+    @staticmethod
+    def _remove_satisfied_attracting_components(graph):
+        # Remove sets of attracting components where all components are satisfied
+        fixed_point_reached = False
+        done_something = False
+        while not fixed_point_reached:
+            fixed_point_reached = True
+            for attracting_components in nx.attracting_components(graph):
+                if all(c.is_satisfied() for c in attracting_components):
+                    graph.remove_nodes_from(attracting_components)
+                    fixed_point_reached = False
+                    done_something = True
+                    break
+        return done_something
+
+    @staticmethod
+    def _transitive_reduction(graph):
+        if nx.is_directed_acyclic_graph(graph):
+            return nx.algorithms.dag.transitive_reduction(graph)
+
+        # It is not possible (rather, it is expensive and not uniquely defined)
+        # to compute the transitive reduction on a graph with cycles
+        # So we:
+        #  - perform a condensation which gives us a DAG
+        #    (by "shrinking" all strongly connected components in a single node)
+        #  - perform a transitive reduction
+        #  - expand the condensed graph back to it's expanded form
+        condensed_graph = nx.algorithms.condensation(graph)
+        mapping = condensed_graph.graph["mapping"]
+        members = nx.get_node_attributes(condensed_graph, "members")
+
+        condensed_graph = nx.algorithms.transitive_reduction(condensed_graph)
+
+        # TODO: review this code, it may be re-adding edges that
+        #  were taken out by the transitive reduction
+        inflated_graph = nx.DiGraph()
+        for condensed_node in condensed_graph.nodes:
+            condensed_node_members = members[condensed_node]
+            subgraph = nx.subgraph_view(graph, filter_node=nxfilters.show_nodes(condensed_node_members))
+            inflated_graph = nx.union(inflated_graph, subgraph)
+
+            for u, v in graph.out_edges(condensed_node_members):
+                v_condensed_node = mapping[v]
+                if condensed_graph.has_edge(condensed_node, v_condensed_node):
+                    inflated_graph.add_edge(u, v)
+
+        return inflated_graph
+
+    def _init_toposorter(self, dependency_graph):
+        for action in dependency_graph.nodes:
+            dependencies = dependency_graph.successors(action)
+            self._toposorter.add(action, *dependencies)
 
     def _run_action(self, action: Action):
-        return action.run(args=self.args)
+        self._running_actions.append(action)
+        self._current_remaining -= 1
+        try:
+            return action.run(args=self.args)
+        finally:
+            self._running_actions.remove(action)
+
+    def _start_display_update(self):
+        self._stop_updating_display = False
+        # Display manager and status bar must be initialized in main thread
+        self._display_manager = enlighten.get_manager()
+        self._status_bar = self._display_manager.status_bar()
+        self._display_thread = threading.Thread(target=self._update_display, name="Display updater")
+        self._display_thread.start()
+
+    def _stop_display_update(self):
+        self._stop_updating_display = True
+
+    def _update_display(self):
+        self._status_bar.color = "bright_white_on_lightslategray"
+        try:
+            while not self._stop_updating_display:
+                running_jobs_str = ", ".join(a.name_for_info for a in self._running_actions)
+                self._status_bar_args = {
+                    "jobs": running_jobs_str,
+                    "current": self._total_remaining - self._current_remaining,
+                    "total": self._total_remaining,
+                }
+                set_terminal_title(f"Running {running_jobs_str}")
+                self._status_bar.status_format = "[{current}/{total}] Running {jobs}"
+                self._status_bar.update(**self._status_bar_args)
+                self._status_bar.refresh()
+                time.sleep(0.3)
+        finally:
+            self._status_bar.close()
+
+
+def has_unsatisfied_cycles(graph):
+    simple_cycles = list(nx.simple_cycles(graph))
+    for cycle in simple_cycles:
+        if not all(c.is_satisfied() for c in cycle):
+            return True
+    return False
+
+
+def has_choices(graph):
+    for node in graph.nodes:
+        if isinstance(node, AnyOfAction) and len(list(graph.successors(node))) > 1:
+            return True
+    return False
+
+
+def keyer(to_assign):
+    def _keyer(action):
+        """
+        Prioritize choices in this order:
+         - installed build
+         - preferred build (either explicitly specified or default)
+         - all others in alphabetical order
+        """
+        if action.is_satisfied():
+            priority = 0
+        elif action is to_assign.preferred_action:
+            priority = 1
+        else:
+            priority = 2
+        return priority, str(action)
+
+    return _keyer
+
+
+def filter_out_unreachable(graph, nodes, roots):
+    shortest_paths = nx.multi_source_dijkstra_path_length(graph, roots)
+    reachable = []
+    unreachable = []
+    for node in nodes:
+        if node not in shortest_paths:
+            unreachable.append(node)
+        else:
+            reachable.append(node)
+    return reachable, unreachable

--- a/orchestra/model/component.py
+++ b/orchestra/model/component.py
@@ -1,13 +1,14 @@
 from typing import Dict
 
 from . import build
+from ..actions import CloneAction
 
 from ..actions.util import run_script
+
 
 class Component:
     def __init__(self,
                  name: str,
-                 default_build_name: str,
                  license: str,
                  from_source: bool,
                  binary_archives: str,
@@ -15,19 +16,25 @@ class Component:
                  ):
         self.name = name
         self.builds: Dict[str, 'build.Build'] = {}
-        self.default_build_name = default_build_name
         self.skip_post_install = skip_post_install
         self.license = license
         self.from_source = from_source
         self.clone: CloneAction = None
         self.binary_archives = binary_archives
+        self.self_hash = None
+        self.recursive_hash = None
+        self._default_build = None
 
-    def add_build(self, bld: 'build.Build'):
+    def add_build(self, bld: 'build.Build', default=False):
         self.builds[bld.name] = bld
+        if default:
+            self._default_build = bld
 
     @property
     def default_build(self):
-        return self.builds[self.default_build_name]
+        if self._default_build is None:
+            raise ValueError(f"The default build for component {self.name} was not set")
+        return self._default_build
 
     def commit(self):
         if self.clone is None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ python-Levenshtein~=0.12.0
 pyelftools~=0.26
 enlighten~=1.6.2
 tqdm~=4.50.2
+graphlib-backport
+networkx~=2.5


### PR DESCRIPTION
## Summary

This branch contains orchestra new action scheduling algorithm.

## Problem

We want an action scheduling algorithm that:

- can handle alternatives, aka "the GCC/libc situation"
- can determine scheduling feasibility ahead of time
- allows to schedule actions in parallel
- handles inconsistent states
  - e.g. gcc is installed but libc is not

### The GCC/libc situation

Builds can now depend on installation of any build from another component. 
We (rev.ng) use/plan to use this feature to:

- allow installing different builds of a dependency
- managing the dependency chain for bootstrapping cross compilers

By design, rev.ng orchestra configuration describes the dependency chain for cross compilers with loops.
This is because when bootstrapping a compiler we want this dependency chain:
```
gcc@stage2 -> libc@default -> gcc@stage1 -> libc@headers
```

Installing `stage2` causes `stage1` to be uninstalled, and installing `libc@default` causes `libc@headers` to be uninstalled.
Because of this if we used the above static dependency chain every time `gcc@stage2` is needed we would need to reinstall everything from `libc@headers` upwards.

Two ways to solve this problem are:

- "cutting" the dependency chain if `gcc@stage1` and/or `libc/headers` are not needed
- specifying that `libc@default` needs "any gcc" and that `gcc@stage1` needs "any libc", so that if `gcc@stage2` and `libc@default` are installed, we can satisfy these dependencies by having `gcc@stage2 -> libc@default` and `libc@default -> gcc@stage2`

The latter solution does imply generating a cyclic dependency cycle, but this is done only if all its components are already installed (a.k.a recognizing there's nothing to do).

## Solution

We first build an initial dependency graph, collecting all dependencies for the "root" actions the user requested (e.g. install `somecomponent`).
This graph contains some special "AnyOf" nodes which represent alternatives. Only one of the successord of these nodes should be picked to satisfy the dependency.

The core step of the algorithm finds assignments for those nodes such that either no cycles are found, or all nodes in the cycles are satisfied.
The search is done such that already installed components and preferred builds (`component~preferredbuild`) are tried first.
The algorithm assigns choices from different strongly connected components independently. This optimization reduces the search space size from intractable to very manageable (in my testing execution time goes from "never" finishing to ~0.1s for resolving `ui/cold-revng` dependency graph).

Then a couple of trivial simplification steps are performed on the graph, and the actions are scheduled opportunistically in topological order, allowing parallel execution.

## Conclusion

I would like to have some feedback/third party testing on it before merging it to master.
If I forgot explaining something important let me know :)