### PR TITLE
Feature: orc shell inline command execution

### DIFF
--- a/orchestra/cmds/shell.py
+++ b/orchestra/cmds/shell.py
@@ -1,4 +1,5 @@
 import argparse
+import shlex
 import os
 from textwrap import dedent
 
@@ -42,7 +43,8 @@ def handle_shell(args):
             cd_to = os.getcwd()
 
     if command:
-        p = run_script(" ".join(command), environment=env, strict_flags=False, check_returncode=False, cwd=cd_to)
+        script_to_run = " ".join(shlex.quote(c) for c in command)
+        p = run_script(script_to_run, environment=env, strict_flags=False, check_returncode=False, cwd=cd_to)
         exit(p.returncode)
 
     user_shell = run_script("getent passwd $(whoami) | cut -d: -f7", quiet=True).stdout.decode("utf-8").strip()

--- a/orchestra/cmds/shell.py
+++ b/orchestra/cmds/shell.py
@@ -1,6 +1,6 @@
 import argparse
-import shlex
 import os
+import shlex
 from textwrap import dedent
 
 from loguru import logger
@@ -10,12 +10,17 @@ from ..model.configuration import Configuration
 
 
 def install_subcommand(sub_argparser):
-    cmd_parser = sub_argparser.add_parser("shell", handler=handle_shell,
-                                          help="Open a shell with the given component environment (experimental). "
-                                               "The shell will start in the component build directory, if it exists. "
-                                               "Otherwise, the CWD will not be changed.",
-                                          )
-    cmd_parser.add_argument("component", nargs="?")
+    cmd_parser = sub_argparser.add_parser(
+        "shell",
+        handler=handle_shell,
+        help="Open a shell with orchestra environment (experimental)."
+    )
+    cmd_parser.add_argument(
+        "--component", "-c",
+        help="Execute in the context of this component. "
+             "The shell will start in the component build directory, if it exists. "
+             "Otherwise, the CWD will not be changed.",
+    )
     cmd_parser.add_argument("command", nargs=argparse.REMAINDER)
 
 


### PR DESCRIPTION
This PR implements `orc shell <component> command`, so it is now possible to execute shell commands in the context of a component without manually typing it into the spawned shell.