### PR TITLE
Improve update command

### DIFF
--- a/orchestra/__init__.py
+++ b/orchestra/__init__.py
@@ -3,6 +3,7 @@ from loguru import logger
 from tqdm import tqdm
 
 from orchestra.cmds.main import main_parser, main_subparsers
+import orchestra.globals
 
 
 class TqdmWrapper:
@@ -17,6 +18,7 @@ def main():
 
     logger.remove(0)
     logger.add(TqdmWrapper(), level=args.loglevel, colorize=True, format="<level>[+] {level}</level> - {message}")
+    orchestra.globals.loglevel = args.loglevel
 
     cmd_parser = main_subparsers.choices.get(args.command_name)
     if not cmd_parser:

--- a/orchestra/actions/action.py
+++ b/orchestra/actions/action.py
@@ -4,7 +4,7 @@ from typing import Set
 
 from loguru import logger
 
-from .util import run_user_script, run_internal_script, get_script_output
+from .util import run_user_script, run_internal_script, get_script_output, try_get_script_output
 # Only used for type hints, package-relative import not possible due to circular reference
 import orchestra.model.configuration
 
@@ -94,6 +94,9 @@ class Action:
 
     def _get_script_output(self, script):
         return get_script_output(script, environment=self.environment)
+
+    def _try_get_script_output(self, script):
+        return try_get_script_output(script, environment=self.environment)
 
 
 class ActionForComponent(Action):

--- a/orchestra/actions/action.py
+++ b/orchestra/actions/action.py
@@ -4,7 +4,7 @@ from typing import Set
 
 from loguru import logger
 
-from .util import run_script
+from .util import run_user_script, run_internal_script, get_script_output
 # Only used for type hints, package-relative import not possible due to circular reference
 import orchestra.model.configuration
 
@@ -23,7 +23,7 @@ class Action:
 
     def _run(self, args):
         """Executes the action"""
-        run_script(self.script, quiet=args.quiet, environment=self.environment)
+        self._run_user_script(self.script)
 
     @property
     def script(self):
@@ -85,6 +85,15 @@ class Action:
 
     def __repr__(self):
         return self.__str__()
+
+    def _run_user_script(self, script):
+        return run_user_script(script, environment=self.environment)
+
+    def _run_internal_script(self, script):
+        return run_internal_script(script, environment=self.environment)
+
+    def _get_script_output(self, script):
+        return get_script_output(script, environment=self.environment)
 
 
 class ActionForComponent(Action):

--- a/orchestra/actions/clone.py
+++ b/orchestra/actions/clone.py
@@ -91,6 +91,7 @@ class CloneAction(ActionForComponent):
                 for commit, branch
                 in parse_regex.findall(result)}
 
+    @property
     def environment(self) -> OrderedDict:
         env = super().environment
         env["GIT_SSH_COMMAND"] = "ssh -oControlPath=~/.ssh/ssh-mux-%r@%h:%p -oControlMaster=auto -o ControlPersist=10"

--- a/orchestra/actions/clone.py
+++ b/orchestra/actions/clone.py
@@ -83,7 +83,7 @@ class CloneAction(ActionForComponent):
         return None, None
 
     def _branches_from_remote(self, remote):
-        result = self._get_script_output(f'git ls-remote -h --refs "{remote}"')
+        result = self._try_get_script_output(f'git ls-remote -h --refs "{remote}"')
 
         parse_regex = re.compile(r"(?P<commit>[a-f0-9]*)\W*refs/heads/(?P<branch>.*)")
 

--- a/orchestra/actions/configure.py
+++ b/orchestra/actions/configure.py
@@ -1,9 +1,9 @@
+from pathlib import Path
 import os
 
 from loguru import logger
 
 from .action import ActionForBuild
-from .util import run_script
 
 
 class ConfigureAction(ActionForBuild):
@@ -22,9 +22,8 @@ class ConfigureAction(ActionForBuild):
             logger.warning("Previous configure probably failed, running configure script in a dirty environment")
             logger.warning(f"You might want to delete the build directory (use `orchestra clean`)")
 
-        result = run_script(self.script, quiet=args.quiet, environment=self.environment)
-        if result.returncode == 0:
-            open(self._configure_successful_path, "w").close()
+        self._run_user_script(self.script)
+        Path(self._configure_successful_path, "w").touch()
 
     @property
     def _configure_successful_path(self):

--- a/orchestra/actions/install.py
+++ b/orchestra/actions/install.py
@@ -47,7 +47,7 @@ class InstallAction(ActionForBuild):
         pre_file_list = self._index_directory(tmp_root + orchestra_root, relative_to=tmp_root + orchestra_root)
 
         install_start_time = time.time()
-        if self.allow_binary_archive and self._binary_archive_exists():
+        if self.allow_binary_archive and self.binary_archive_exists():
             self._install_from_binary_archive(args)
             source = "binary archives"
         elif self.allow_build:
@@ -141,7 +141,7 @@ class InstallAction(ActionForBuild):
         git_lfs.fetch(binary_archive_repo_dir, only=[os.path.realpath(binary_archive_path)])
 
     def _extract_binary_archive(self):
-        if not self._binary_archive_exists():
+        if not self.binary_archive_exists():
             raise Exception("Binary archive not found!")
 
         archive_filepath = self._binary_archive_filepath()
@@ -153,7 +153,7 @@ class InstallAction(ActionForBuild):
         self._run_internal_script(script)
 
     def _implicit_dependencies(self):
-        if self.allow_binary_archive and self._binary_archive_exists() or not self.allow_build:
+        if self.allow_binary_archive and self.binary_archive_exists() or not self.allow_build:
             return set()
         else:
             return {self.build.configure}
@@ -389,7 +389,7 @@ class InstallAction(ActionForBuild):
                 return try_archive_path
         return None
 
-    def _binary_archive_exists(self):
+    def binary_archive_exists(self):
         return self._binary_archive_filepath() is not None
 
     @property

--- a/orchestra/actions/install.py
+++ b/orchestra/actions/install.py
@@ -9,7 +9,7 @@ from loguru import logger
 
 from .action import ActionForBuild
 from .uninstall import uninstall
-from .util import OrchestraException
+from ..util import OrchestraException
 from .. import git_lfs
 from ..util import is_installed
 

--- a/orchestra/actions/install.py
+++ b/orchestra/actions/install.py
@@ -9,7 +9,7 @@ from loguru import logger
 
 from .action import ActionForBuild
 from .uninstall import uninstall
-from .util import run_script, OrchestraException
+from .util import OrchestraException
 from .. import git_lfs
 from ..util import is_installed
 
@@ -76,7 +76,7 @@ class InstallAction(ActionForBuild):
                 uninstall(self.build.component.name, self.config)
 
             logger.info("Merging installed files into orchestra root directory")
-            self._merge(args.quiet)
+            self._merge()
 
             # Write file metadata and index
             os.makedirs(self.config.installed_component_metadata_dir(), exist_ok=True)
@@ -114,7 +114,7 @@ class InstallAction(ActionForBuild):
             touch "${TMP_ROOT}${ORCHESTRA_ROOT}/share/info/dir"
             mkdir -p "${TMP_ROOT}${ORCHESTRA_ROOT}/libexec"
             """)
-        run_script(script, environment=self.environment)
+        self._run_internal_script(script)
 
     def _install_from_binary_archive(self, args):
         # TODO: handle nonexisting binary archives
@@ -150,7 +150,7 @@ class InstallAction(ActionForBuild):
             cd "$TMP_ROOT$ORCHESTRA_ROOT"
             tar xaf "{archive_filepath}"
             """)
-        run_script(script, environment=self.environment, quiet=True)
+        self._run_internal_script(script)
 
     def _implicit_dependencies(self):
         if self.allow_binary_archive and self._binary_archive_exists() or not self.allow_build:
@@ -166,7 +166,7 @@ class InstallAction(ActionForBuild):
         env["RUN_TESTS"] = "1" if (self.build.test and args.test) else "0"
 
         logger.info("Executing install script")
-        run_script(self.script, quiet=args.quiet, environment=env)
+        self._run_user_script(self.script)
 
         logger.info("Removing conflicting files")
         self._remove_conflicting_files()
@@ -174,9 +174,9 @@ class InstallAction(ActionForBuild):
         if self.build.component.skip_post_install:
             logger.info("Skipping post install")
         else:
-            self._post_install(args.quiet)
+            self._post_install()
 
-    def _post_install(self, quiet):
+    def _post_install(self):
         logger.info("Dropping absolute paths from pkg-config")
         self._drop_absolute_pkgconfig_paths()
 
@@ -211,14 +211,14 @@ class InstallAction(ActionForBuild):
                 echo "Couldn't find {source}"
                 exit 1
                 """)
-            run_script(script, environment=self.environment)
+            self._run_internal_script(script)
 
     def _remove_conflicting_files(self):
         script = dedent("""
             if test -d "$TMP_ROOT/$ORCHESTRA_ROOT/share/info"; then rm -rf "$TMP_ROOT/$ORCHESTRA_ROOT/share/info"; fi
             if test -d "$TMP_ROOT/$ORCHESTRA_ROOT/share/locale"; then rm -rf "$TMP_ROOT/$ORCHESTRA_ROOT/share/locale"; fi
             """)
-        run_script(script, environment=self.environment)
+        self._run_internal_script(script)
 
     def _drop_absolute_pkgconfig_paths(self):
         script = dedent("""
@@ -229,13 +229,13 @@ class InstallAction(ActionForBuild):
                     -exec sed -i 's|/*'"$ORCHESTRA_ROOT"'/*|${pcfiledir}/../..|g' {} ';'
             fi
             """)
-        run_script(script, environment=self.environment)
+        self._run_internal_script(script)
 
     def _purge_libtools_files(self):
         script = dedent("""
             find "${TMP_ROOT}${ORCHESTRA_ROOT}" -name "*.la" -type f -delete
             """)
-        run_script(script, environment=self.environment)
+        self._run_internal_script(script)
 
     def _hard_to_symbolic(self):
         duplicates = defaultdict(list)
@@ -271,7 +271,7 @@ class InstallAction(ActionForBuild):
                 fi
             done
             """)
-        run_script(fix_rpath_script, environment=self.environment)
+        self._run_internal_script(fix_rpath_script)
 
     def _replace_ndebug(self, disable_debugging):
         debug, ndebug = ("0", "1") if disable_debugging else ("1", "0")
@@ -286,11 +286,11 @@ class InstallAction(ActionForBuild):
                     -e 's|^\(\s*#\s*if\s\+.*\)defined(NDEBUG)|\1{ndebug}|' \
                     {{}} ';'
             """)
-        run_script(patch_ndebug_script, environment=self.environment)
+        self._run_internal_script(patch_ndebug_script)
 
-    def _merge(self, quiet):
+    def _merge(self):
         copy_command = f'cp -farl "$TMP_ROOT/$ORCHESTRA_ROOT/." "$ORCHESTRA_ROOT"'
-        run_script(copy_command, quiet=quiet, environment=self.environment)
+        self._run_internal_script(copy_command)
 
     def _binary_archive_repo_name(self):
         # Select the binary archives repository to employ
@@ -324,7 +324,7 @@ class InstallAction(ActionForBuild):
             mkdir -p "{binary_archive_containing_dir}"
             mv "{binary_archive_tmp_path}" "{binary_archive_path}"
             """)
-        run_script(script, environment=self.environment)
+        self._run_internal_script(script)
 
     def update_binary_archive_symlink(self):
         logger.info("Updating binary archive symlink")
@@ -332,11 +332,9 @@ class InstallAction(ActionForBuild):
         binary_archive_repo_name = self._binary_archive_repo_name()
         archive_dirname = self.build.binary_archive_dir
 
-        orchestra_config_branch = run_script(
+        orchestra_config_branch = self._get_script_output(
             'git -C "$ORCHESTRA_DOTDIR" rev-parse --abbrev-ref HEAD',
-            quiet=True,
-            environment=self.environment
-        ).stdout.decode("utf-8").strip().replace("/", "-")
+        ).strip().replace("/", "-")
 
         archive_path = os.path.join(self.environment["BINARY_ARCHIVES"],
                                     binary_archive_repo_name,
@@ -379,7 +377,7 @@ class InstallAction(ActionForBuild):
         return paths
 
     def _cleanup_tmproot(self):
-        run_script('rm -rf "$TMP_ROOT"', environment=self.environment, quiet=True)
+        self._run_internal_script('rm -rf "$TMP_ROOT"')
 
     def _binary_archive_filepath(self):
         archives_dir = self.environment["BINARY_ARCHIVES"]

--- a/orchestra/actions/util.py
+++ b/orchestra/actions/util.py
@@ -1,7 +1,9 @@
 import subprocess
 from collections import OrderedDict
+
 from loguru import logger
 
+from .. import globals
 from ..util import export_environment, OrchestraException
 
 bash_prelude = """
@@ -11,21 +13,23 @@ set -o pipefail
 """
 
 
-def run_script(script,
-               quiet=False,
-               environment: OrderedDict = None,
-               strict_flags=True,
-               check_returncode=True,
-               cwd=None,
-               ):
-    """Helper for running shell scripts.
+def _run_script(
+        script,
+        environment: [OrderedDict, dict] = None,
+        strict_flags=True,
+        cwd=None,
+        loglevel="INFO",
+        stdout=None,
+        stderr=None,
+):
+    """Helper for running shell scripts. Should not be used directly.
     :param script: the script to run
-    :param quiet: if True the output of the command is not shown to the user,
-    but instead captured and accessible from the `stdout` and `stderr` properties of the returned value.
     :param environment: will be exported at the beginning of the script
     :param strict_flags: if True, a prelude is prepended to the script to help catch errors
-    :param check_returncode: if True an exception is raised unless the script returns 0
     :param cwd: if not None, the command is executed in the specified path
+    :param loglevel: log debug informations at this level
+    :param stdout: passed as the "stdout" parameter to subprocess.run
+    :param stderr: passed as the "stderr" parameter to subprocess.run
     :return: a subprocess.CompletedProcess instance
     """
     if strict_flags:
@@ -38,24 +42,188 @@ def run_script(script,
 
     script_to_run += script
 
+    logger.log(loglevel, f"The following script is going to be executed:\n" + script.strip())
+    return subprocess.run(["/bin/bash", "-c", script_to_run], stdout=stdout, stderr=stderr, cwd=cwd)
+
+
+def run_internal_script(script, environment: OrderedDict = None, check_returncode=True):
+    """Helper for running internal scripts.
+    :param script: the script to run
+    :param environment: optional additional environment variables
+    :param check_returncode: if True, raise an exception if the script returns a nonzero exit code
+    :return: a subprocess.CompletedProcess instance
+    """
+    result = _run_script(
+        script,
+        environment=environment,
+        loglevel="DEBUG",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+    if check_returncode and result.returncode != 0:
+        err_msg = f"Script failed with return code {result.returncode}"
+        logger.error(err_msg)
+        logger.error(f"The script was: \n{script}")
+        logger.error(f"The output was: \n{try_decode(result.stdout)}")
+        raise OrchestraException(err_msg)
+
+    logger.debug(f"The script output was: \n{try_decode(result.stdout)}")
+
+    return result
+
+
+def run_user_script(script, environment: OrderedDict = None, check_returncode=True):
+    """Helper for running user scripts
+    :param script: the script to run
+    :param environment: optional additional environment variables
+    :param check_returncode: if True, raise an exception if the script returns a nonzero exit code
+    :return: a subprocess.CompletedProcess instance
+    """
+
+    quiet = globals.loglevel not in ["TRACE", "DEBUG", "INFO"]
     if quiet:
         stdout = subprocess.PIPE
-        stderr = subprocess.PIPE
+        stderr = subprocess.STDOUT
     else:
-        logger.info(f"The following script is going to be executed:\n" + script.strip())
-        logger.info(f"Script output:")
         stdout = None
         stderr = None
 
-    result = subprocess.run(["/bin/bash", "-c", script_to_run], stdout=stdout, stderr=stderr, cwd=cwd)
+    result = _run_script(
+        script,
+        environment=environment,
+        loglevel="INFO",
+        stdout=stdout,
+        stderr=stderr,
+    )
+
     if check_returncode and result.returncode != 0:
-        raise OrchestraException(f"Script failed with return code {result.returncode}")
+        err_msg = f"Script failed with return code {result.returncode}"
+        logger.error(err_msg)
+        logger.error(f"The script was: \n{script}")
+        if quiet:
+            logger.error(f"The output was: \n{try_decode(result.stdout)}")
+        raise OrchestraException(err_msg)
 
     return result
+
+
+def get_script_output(script, environment: OrderedDict = None, check_returncode=True, decode_as="utf-8"):
+    """Helper for getting stdout of a script
+    :param script: the script to run
+    :param environment: optional additional environment variables
+    :param check_returncode: if True, raise an exception if the script returns a nonzero exit code
+    :param decode_as: decode the script output using this encoding
+    :return: the stdout produced by the script
+    """
+    result = _run_script(
+        script,
+        environment=environment,
+        loglevel="DEBUG",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    if check_returncode and result.returncode != 0:
+        err_msg = f"Script failed with return code {result.returncode}"
+        logger.error(err_msg)
+        logger.error(f"The script was: \n{script}")
+        logger.error(f"Stdout was: \n{try_decode(result.stdout)}")
+        logger.error(f"Stderr was: \n{try_decode(result.stderr)}")
+        raise OrchestraException(err_msg)
+
+    return result.stdout.decode(decode_as)
+
+
+def _run_subprocess(
+        argv,
+        environment: [OrderedDict, dict] = None,
+        cwd=None,
+        loglevel="INFO",
+        stdout=None,
+        stderr=None,
+):
+    """Helper for running a subprocess. Should not be used directly.
+    :param argv: the argv passed to subprocess.run
+    :param environment: environment variables
+    :param cwd: if not None, the command is executed in the specified path
+    :param loglevel: log debug informations at this level
+    :param stdout: passed as the "stdout" parameter to subprocess.run
+    :param stderr: passed as the "stderr" parameter to subprocess.run
+    :return: a subprocess.CompletedProcess instance
+    """
+
+    logger.log(loglevel, f"The following program is going to be executed: {argv}")
+    return subprocess.run(argv, stdout=stdout, stderr=stderr, cwd=cwd, env=environment)
+
+
+def run_internal_subprocess(
+        argv,
+        environment: [OrderedDict, dict] = None,
+        cwd=None,
+        check_returncode=True,
+):
+    """Helper for running an internal subprocess.
+    :param argv: the argv passed to subprocess.run
+    :param environment: environment variables
+    :param cwd: if not None, the command is executed in the specified path
+    :param check_returncode: if True, raise an exception if the script returns a nonzero exit code
+    :return: a subprocess.CompletedProcess instance
+    """
+
+    result = _run_subprocess(
+        argv,
+        environment=environment,
+        cwd=cwd,
+        loglevel="DEBUG",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT
+    )
+    if check_returncode and result.returncode != 0:
+        err_msg = f"Subprocess failed with return code {result.returncode}"
+        logger.error(err_msg)
+        logger.error(f"The command was: \n{argv}")
+        logger.error(f"Output was: \n{try_decode(result.stdout)}")
+        raise OrchestraException(err_msg)
+
+    logger.debug(f"The subprocess output was: \n{try_decode(result.stdout)}")
+
+    return result
+
+
+def get_subprocess_output(
+        argv,
+        environment=None,
+        check_returncode=True,
+        decode_as="utf-8",
+):
+    """
+    Helper to run a subprocess and get its output
+    :param argv: the argv passed to subprocess.run
+    :param environment: environment variables
+    :param check_returncode: if True, raise an exception if the script returns a nonzero exit code
+    :param decode_as: decode the output using this encoding
+    :return: the decoded stdout of the subprocess
+    """
+    result = _run_subprocess(
+        argv,
+        environment=environment,
+        loglevel="DEBUG",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if check_returncode and result.returncode != 0:
+        err_msg = f"Subprocess failed with return code {result.returncode}"
+        logger.error(err_msg)
+        logger.error(f"The command was: \n{argv}")
+        logger.error(f"Stdout was: \n{try_decode(result.stdout)}")
+        logger.error(f"Stderr was: \n{try_decode(result.stderr)}")
+        raise OrchestraException(err_msg)
+    return result.stdout.decode(decode_as)
 
 
 def try_decode(stream, encoding="utf-8"):
     try:
         return stream.decode(encoding)
-    except Exception as e:
+    except ValueError as e:
         return stream

--- a/orchestra/actions/util.py
+++ b/orchestra/actions/util.py
@@ -108,7 +108,7 @@ def run_user_script(script, environment: OrderedDict = None, check_returncode=Tr
     return result
 
 
-def get_script_output(script, environment: OrderedDict = None, check_returncode=True, decode_as="utf-8"):
+def _get_script_output(script, environment: OrderedDict = None, check_returncode=True, decode_as="utf-8"):
     """Helper for getting stdout of a script
     :param script: the script to run
     :param environment: optional additional environment variables
@@ -133,6 +133,26 @@ def get_script_output(script, environment: OrderedDict = None, check_returncode=
         raise OrchestraException(err_msg)
 
     return result.stdout.decode(decode_as)
+
+
+def get_script_output(script, environment: OrderedDict = None, decode_as="utf-8"):
+    """Helper for getting stdout of a script. If the script returns a nonzero exit code an OrchestraException is raised.
+    :param script: the script to run
+    :param environment: optional additional environment variables
+    :param decode_as: decode the script output using this encoding
+    :return: the stdout produced by the script
+    """
+    return _get_script_output(script, environment=environment, check_returncode=True, decode_as=decode_as)
+
+
+def try_get_script_output(script, environment: OrderedDict = None, decode_as="utf-8"):
+    """Helper for getting stdout of a script. If the script returns nonzero an empty output will be returned.
+    :param script: the script to run
+    :param environment: optional additional environment variables
+    :param decode_as: decode the script output using this encoding
+    :return: the stdout produced by the script
+    """
+    return _get_script_output(script, environment=environment, check_returncode=False, decode_as=decode_as)
 
 
 def _run_subprocess(

--- a/orchestra/actions/util/__init__.py
+++ b/orchestra/actions/util/__init__.py
@@ -1,0 +1,126 @@
+from collections import OrderedDict
+
+from .impl import _get_script_output
+from .impl import _get_subprocess_output
+from .impl import _run_internal_script
+from .impl import _run_internal_subprocess
+from .impl import _run_user_script
+
+
+def run_internal_script(script, environment: OrderedDict = None):
+    """Helper for running internal scripts.
+    If the script returns a nonzero exit code an OrchestraException is raised.
+    :param script: the script to run
+    :param environment: optional additional environment variables
+    :return: a subprocess.CompletedProcess instance
+    """
+    return _run_internal_script(script, environment=environment, check_returncode=True)
+
+
+def try_run_internal_script(script, environment: OrderedDict = None):
+    """Helper for running internal scripts.
+    :param script: the script to run
+    :param environment: optional additional environment variables
+    :return: a subprocess.CompletedProcess instance
+    """
+    return _run_internal_script(script, environment=environment, check_returncode=False)
+
+
+def run_user_script(script, environment: OrderedDict = None):
+    """Helper for running user scripts.
+    If the script returns a nonzero exit code an OrchestraException is raised.
+    :param script: the script to run
+    :param environment: optional additional environment variables
+    :return: a subprocess.CompletedProcess instance
+    """
+    return _run_user_script(script, environment=environment, check_returncode=True)
+
+
+def try_run_user_script(script, environment: OrderedDict = None):
+    """Helper for running user scripts.
+    :param script: the script to run
+    :param environment: optional additional environment variables
+    :return: a subprocess.CompletedProcess instance
+    """
+    return _run_user_script(script, environment=environment, check_returncode=False)
+
+
+def get_script_output(script, environment: OrderedDict = None, decode_as="utf-8"):
+    """Helper for getting stdout of a script.
+    If the script returns a nonzero exit code an OrchestraException is raised.
+    :param script: the script to run
+    :param environment: optional additional environment variables
+    :param decode_as: decode the script output using this encoding
+    :return: the stdout produced by the script
+    """
+    return _get_script_output(script, environment=environment, check_returncode=True, decode_as=decode_as)
+
+
+def try_get_script_output(script, environment: OrderedDict = None, decode_as="utf-8"):
+    """Helper for getting stdout of a script. If the script returns nonzero an empty output will be returned.
+    :param script: the script to run
+    :param environment: optional additional environment variables
+    :param decode_as: decode the script output using this encoding
+    :return: the stdout produced by the script
+    """
+    return _get_script_output(script, environment=environment, check_returncode=False, decode_as=decode_as)
+
+
+def run_internal_subprocess(
+        argv,
+        environment: [OrderedDict, dict] = None,
+        cwd=None,
+):
+    """Helper for running an internal subprocess.
+    If the subprocess returns a nonzero exit code an OrchestraException is raised.
+    :param argv: the argv passed to subprocess.run
+    :param environment: environment variables
+    :param cwd: if not None, the command is executed in the specified path
+    :return: a subprocess.CompletedProcess instance
+    """
+    return _run_internal_subprocess(argv, environment=environment, cwd=cwd, check_returncode=True)
+
+
+def try_run_internal_subprocess(
+        argv,
+        environment: [OrderedDict, dict] = None,
+        cwd=None,
+):
+    """Helper for running an internal subprocess.
+    :param argv: the argv passed to subprocess.run
+    :param environment: environment variables
+    :param cwd: if not None, the command is executed in the specified path
+    :return: a subprocess.CompletedProcess instance
+    """
+    return _run_internal_subprocess(argv, environment=environment, cwd=cwd, check_returncode=False)
+
+
+def get_subprocess_output(
+        argv,
+        environment=None,
+        decode_as="utf-8",
+):
+    """
+    Helper to run a subprocess and get its output.
+    If the subprocess returns a nonzero exit code an OrchestraException is raised.
+    :param argv: the argv passed to subprocess.run
+    :param environment: environment variables
+    :param decode_as: decode the output using this encoding
+    :return: the decoded stdout of the subprocess
+    """
+    return _get_subprocess_output(argv, environment=environment, decode_as=decode_as, check_returncode=True)
+
+
+def try_get_subprocess_output(
+        argv,
+        environment=None,
+        decode_as="utf-8",
+):
+    """
+    Helper to run a subprocess and get its output.
+    :param argv: the argv passed to subprocess.run
+    :param environment: environment variables
+    :param decode_as: decode the output using this encoding
+    :return: the decoded stdout of the subprocess
+    """
+    return _get_subprocess_output(argv, environment=environment, decode_as=decode_as, check_returncode=False)

--- a/orchestra/actions/util/impl.py
+++ b/orchestra/actions/util/impl.py
@@ -3,8 +3,8 @@ from collections import OrderedDict
 
 from loguru import logger
 
-from .. import globals
-from ..util import export_environment, OrchestraException
+from ... import globals
+from ...util import export_environment, OrchestraException
 
 bash_prelude = """
 set -o errexit
@@ -22,7 +22,7 @@ def _run_script(
         stdout=None,
         stderr=None,
 ):
-    """Helper for running shell scripts. Should not be used directly.
+    """Helper for running shell scripts.
     :param script: the script to run
     :param environment: will be exported at the beginning of the script
     :param strict_flags: if True, a prelude is prepended to the script to help catch errors
@@ -46,7 +46,7 @@ def _run_script(
     return subprocess.run(["/bin/bash", "-c", script_to_run], stdout=stdout, stderr=stderr, cwd=cwd)
 
 
-def run_internal_script(script, environment: OrderedDict = None, check_returncode=True):
+def _run_internal_script(script, environment: OrderedDict = None, check_returncode=True):
     """Helper for running internal scripts.
     :param script: the script to run
     :param environment: optional additional environment variables
@@ -73,7 +73,7 @@ def run_internal_script(script, environment: OrderedDict = None, check_returncod
     return result
 
 
-def run_user_script(script, environment: OrderedDict = None, check_returncode=True):
+def _run_user_script(script, environment: OrderedDict = None, check_returncode=True):
     """Helper for running user scripts
     :param script: the script to run
     :param environment: optional additional environment variables
@@ -135,26 +135,6 @@ def _get_script_output(script, environment: OrderedDict = None, check_returncode
     return result.stdout.decode(decode_as)
 
 
-def get_script_output(script, environment: OrderedDict = None, decode_as="utf-8"):
-    """Helper for getting stdout of a script. If the script returns a nonzero exit code an OrchestraException is raised.
-    :param script: the script to run
-    :param environment: optional additional environment variables
-    :param decode_as: decode the script output using this encoding
-    :return: the stdout produced by the script
-    """
-    return _get_script_output(script, environment=environment, check_returncode=True, decode_as=decode_as)
-
-
-def try_get_script_output(script, environment: OrderedDict = None, decode_as="utf-8"):
-    """Helper for getting stdout of a script. If the script returns nonzero an empty output will be returned.
-    :param script: the script to run
-    :param environment: optional additional environment variables
-    :param decode_as: decode the script output using this encoding
-    :return: the stdout produced by the script
-    """
-    return _get_script_output(script, environment=environment, check_returncode=False, decode_as=decode_as)
-
-
 def _run_subprocess(
         argv,
         environment: [OrderedDict, dict] = None,
@@ -177,13 +157,13 @@ def _run_subprocess(
     return subprocess.run(argv, stdout=stdout, stderr=stderr, cwd=cwd, env=environment)
 
 
-def run_internal_subprocess(
+def _run_internal_subprocess(
         argv,
         environment: [OrderedDict, dict] = None,
         cwd=None,
         check_returncode=True,
 ):
-    """Helper for running an internal subprocess.
+    """Helper for running an internal subprocess. Not to be used directly.
     :param argv: the argv passed to subprocess.run
     :param environment: environment variables
     :param cwd: if not None, the command is executed in the specified path
@@ -211,7 +191,7 @@ def run_internal_subprocess(
     return result
 
 
-def get_subprocess_output(
+def _get_subprocess_output(
         argv,
         environment=None,
         check_returncode=True,

--- a/orchestra/cmds/main.py
+++ b/orchestra/cmds/main.py
@@ -27,8 +27,6 @@ main_parser = argparse.ArgumentParser()
 logging_group = main_parser.add_argument_group(title="Logging options")
 logging_group.add_argument("--loglevel", "-v", default="INFO",
                            choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"])
-logging_group.add_argument("--quiet", "-q", action="store_true",
-                           help="Do not show output of executed commands")
 
 config_group = main_parser.add_argument_group(title="Configuration options")
 config_group.add_argument("--no-config-cache", dest="config_cache", default=True, action="store_false",

--- a/orchestra/cmds/shell.py
+++ b/orchestra/cmds/shell.py
@@ -5,7 +5,8 @@ from textwrap import dedent
 
 from loguru import logger
 
-from ..actions.util import get_script_output, _run_script
+from ..actions.util import get_script_output
+from ..actions.util.impl import _run_script
 from ..model.configuration import Configuration
 
 

--- a/orchestra/cmds/update.py
+++ b/orchestra/cmds/update.py
@@ -128,7 +128,12 @@ def git_clean(directory):
 
 
 def git_reset_hard(directory, ref="master"):
-    return run_internal_subprocess(["git", "-C", directory, "reset", "--hard", ref])
+    env = os.environ.copy()
+    env["GIT_LFS_SKIP_SMUDGE"] = "1"
+    return run_internal_subprocess(
+        ["git", "-C", directory, "reset", "--hard", ref],
+        environment=env,
+    )
 
 
 def git_pull(directory):

--- a/orchestra/cmds/update.py
+++ b/orchestra/cmds/update.py
@@ -71,8 +71,9 @@ def handle_update(args):
                 failed_pulls.append(f"Repository {component.name}")
 
     if failed_pulls:
-        formatted_failed_pulls = "\n".join([f"  {repo}" for repo in failed_pulls])
-        failed_git_pull_suggestion = dedent(f"""
+        formatted_failed_pulls = "\n".join([f"  - {repo}" for repo in failed_pulls])
+        # Note: f-strings don't account for indentation, using a template is more practical
+        failed_git_pull_template = dedent("""
         Could not git pull --ff-only the following repositories:
         {formatted_failed_pulls}
 
@@ -82,6 +83,7 @@ def handle_update(args):
             - `git pull --rebase`, to pull remote changes and apply your commits on top
             - `git push` your changes to the remotes
         """)
+        failed_git_pull_suggestion = failed_git_pull_template.format(formatted_failed_pulls=formatted_failed_pulls)
         logger.error(failed_git_pull_suggestion)
 
 

--- a/orchestra/cmds/update.py
+++ b/orchestra/cmds/update.py
@@ -4,7 +4,7 @@ from textwrap import dedent
 from loguru import logger
 from tqdm import tqdm
 
-from ..actions.util import run_internal_subprocess
+from ..actions.util import run_internal_subprocess, try_run_internal_subprocess
 from ..model.configuration import Configuration
 from ..util import OrchestraException
 
@@ -128,7 +128,7 @@ def git_reset_hard(directory, ref="master"):
 def git_pull(directory):
     env = os.environ.copy()
     env["GIT_LFS_SKIP_SMUDGE"] = "1"
-    result = run_internal_subprocess(
+    result = try_run_internal_subprocess(
         ["git", "-C", directory, "pull", "--ff-only"],
         environment=env,
     )

--- a/orchestra/globals.py
+++ b/orchestra/globals.py
@@ -1,0 +1,2 @@
+global loglevel
+loglevel = "INFO"

--- a/orchestra/model/component.py
+++ b/orchestra/model/component.py
@@ -4,7 +4,6 @@ from . import build
 from ..actions import CloneAction
 
 
-
 class Component:
     def __init__(self,
                  name: str,

--- a/orchestra/model/configuration.py
+++ b/orchestra/model/configuration.py
@@ -15,7 +15,8 @@ from loguru import logger
 from . import build as bld
 from . import component as comp
 from ..actions import CloneAction, ConfigureAction, InstallAction, AnyOfAction
-from ..actions.util import get_script_output, run_internal_subprocess, get_subprocess_output
+from ..actions.util import get_script_output, try_run_internal_subprocess, get_subprocess_output, \
+    try_get_subprocess_output
 from ..util import parse_component_name, parse_dependency
 
 
@@ -32,7 +33,7 @@ def follow_redirects(url, max=3):
 
     new_url = None
     with TemporaryDirectory() as temporary_directory:
-        result = run_internal_subprocess(
+        result = try_run_internal_subprocess(
             ["git", "clone", url, temporary_directory],
             environment=env,
         )
@@ -316,7 +317,7 @@ class Configuration:
         logger.info("Populating default remotes for repositories and binary archives")
         logger.info("Remember to run `orc update` next")
 
-        git_output = get_subprocess_output(
+        git_output = try_get_subprocess_output(
             ["git", "-C", self.orchestra_dotdir, "config", "--get-regexp", r"remote\.[^.]*\.url"]
         )
         remotes_re = re.compile(r"remote\.(?P<name>[^.]*)\.url (?P<url>.*)$")

--- a/orchestra/model/configuration.py
+++ b/orchestra/model/configuration.py
@@ -2,7 +2,6 @@ import hashlib
 import json
 import os
 import re
-import subprocess
 from collections import OrderedDict
 from itertools import repeat
 from tempfile import TemporaryDirectory
@@ -16,7 +15,7 @@ from loguru import logger
 from . import build as bld
 from . import component as comp
 from ..actions import CloneAction, ConfigureAction, InstallAction, AnyOfAction
-from ..actions.util import run_script
+from ..actions.util import get_script_output, run_internal_subprocess, get_subprocess_output
 from ..util import parse_component_name, parse_dependency
 
 
@@ -25,18 +24,18 @@ def follow_redirects(url, max=3):
         return url
 
     # TODO: this code is duplicated in several places
-    env = {
+    env = os.environ.copy()
+    env.update({
         "GIT_SSH_COMMAND": "ssh -oControlPath=~/.ssh/ssh-mux-%r@%h:%p -oControlMaster=auto -o ControlPersist=10",
         "GIT_LFS_SKIP_SMUDGE": "1",
-    }
+    })
 
     new_url = None
     with TemporaryDirectory() as temporary_directory:
-        # TODO: we're not printing the output
-        result = run_script(f"""git clone "{url}" "{temporary_directory}" """,
-                            environment=env,
-                            quiet=True,
-                            check_returncode=False)
+        result = run_internal_subprocess(
+            ["git", "clone", url, temporary_directory],
+            environment=env,
+        )
         if result.returncode != 0:
             logger.info(f"Could not clone binary archive from remote {url}!")
             logger.info(result.stdout.decode("utf8").strip())
@@ -316,10 +315,12 @@ class Configuration:
         logger.info(f"Creating default user options in {relative_path}")
         logger.info("Populating default remotes for repositories and binary archives")
         logger.info("Remember to run `orc update` next")
-        git_output = subprocess.check_output(
+
+        git_output = get_subprocess_output(
             ["git", "-C", self.orchestra_dotdir, "config", "--get-regexp", r"remote\.[^.]*\.url"]
-        ).decode("utf-8")
+        )
         remotes_re = re.compile(r"remote\.(?P<name>[^.]*)\.url (?P<url>.*)$")
+
         remotes = {}
         for line in git_output.splitlines(keepends=False):
             match = remotes_re.match(line)
@@ -401,7 +402,7 @@ class Configuration:
         ytt = os.path.join(os.path.dirname(__file__), "..", "support", "ytt")
         env = os.environ.copy()
         env["GOCG"] = "off"
-        expanded_yaml = subprocess.check_output(f"'{ytt}' -f {config_dir}", shell=True, env=env).decode("utf-8")
+        expanded_yaml = get_subprocess_output([ytt, "-f", config_dir], environment=env)
         parsed_config = yaml.safe_load(expanded_yaml)
 
         if use_cache:
@@ -416,14 +417,8 @@ class Configuration:
     def hash_config_dir(self):
         config_dir = os.path.join(self.orchestra_dotdir, "config")
         hash_script = f"""find "{config_dir}" -type f -print0 | sort -z | xargs -0 sha1sum | sha1sum"""
-        config_hash = subprocess.check_output(hash_script, shell=True).decode("utf-8").strip().partition(" ")[0]
+        config_hash = get_script_output(hash_script).strip().partition(" ")[0]
         return config_hash
-
-
-def hash_config_dir(config_dir):
-    hash_script = f"""find "{config_dir}" -type f -print0 | sort -z | xargs -0 sha1sum | sha1sum"""
-    config_hash = subprocess.check_output(hash_script, shell=True).decode("utf-8").strip().partition(" ")[0]
-    return config_hash
 
 
 def set_self_hash(component: comp.Component, component_yaml):

--- a/orchestra/util.py
+++ b/orchestra/util.py
@@ -5,8 +5,10 @@ import sys
 from collections import OrderedDict
 from typing import Union
 
+
 class OrchestraException(Exception):
     pass
+
 
 def parse_component_name(component_spec):
     tmp = component_spec.split("@")


### PR DESCRIPTION
This PR addresses issue #8:
* [x] Discard any changes made to binary archives and reset them to master. Users are not supposed to create archives. They should expected them to be discarded.
* [x] git pull output should not be shown
* [x] Indentation needs to be fixed. It now looks like this:
  ```
        Could not git pull --ff-only the following repositories:
          Repository llvm
  Repository revng
  Repository revng-c
  ```
* [x] If a component is built from source, not being able to update should be reported but it should not trigger an error.
* [x] We need a --reinstall flag that reinstalls all the installed packages. Maybe we should make a command orc upgrade (mimicking the apt parlance).
* [ ] Not strictly related to updates, but when a binary archive is not found we should output a diagnostic message saying what binary archives are available and what are the commit and recursive hashes we were looking for