### PR TITLE
Fix ordering issues between actions of the same component

### DIFF
--- a/orchestra/cmds/graph.py
+++ b/orchestra/cmds/graph.py
@@ -25,8 +25,6 @@ def install_subcommand(sub_argparser):
                             help="Don't remove choices")
     cmd_parser.add_argument("--no-remove-satisfied-leaves", action="store_true",
                             help="Don't remove satisfied leaves")
-    cmd_parser.add_argument("--no-component-ordering", action="store_true",
-                            help="Don't enforce intra-component ordering")
     cmd_parser.add_argument("--no-transitive-reduction", action="store_true",
                             help="Don't perform transitive reduction")
 
@@ -63,7 +61,6 @@ def handle_graph(args):
             remove_unreachable=not args.no_remove_unreachable,
             simplify_anyof=not args.no_simplify_anyof,
             remove_satisfied=not args.no_remove_satisfied_leaves,
-            intra_component_ordering=not args.no_component_ordering,
             transitive_reduction=not args.no_transitive_reduction
         )
     graphviz_format = nx.nx_agraph.to_agraph(graph)

--- a/orchestra/cmds/graph.py
+++ b/orchestra/cmds/graph.py
@@ -25,6 +25,8 @@ def install_subcommand(sub_argparser):
                             help="Don't remove choices")
     cmd_parser.add_argument("--no-remove-satisfied-leaves", action="store_true",
                             help="Don't remove satisfied leaves")
+    cmd_parser.add_argument("--no-component-ordering", action="store_true",
+                            help="Don't enforce intra-component ordering")
     cmd_parser.add_argument("--no-transitive-reduction", action="store_true",
                             help="Don't perform transitive reduction")
 
@@ -61,6 +63,7 @@ def handle_graph(args):
             remove_unreachable=not args.no_remove_unreachable,
             simplify_anyof=not args.no_simplify_anyof,
             remove_satisfied=not args.no_remove_satisfied_leaves,
+            intra_component_ordering=not args.no_component_ordering,
             transitive_reduction=not args.no_transitive_reduction
         )
     graphviz_format = nx.nx_agraph.to_agraph(graph)

--- a/orchestra/executor.py
+++ b/orchestra/executor.py
@@ -43,7 +43,6 @@ class Executor:
         try:
             self._toposorter.prepare()
         except graphlib.CycleError as e:
-            # TODO: replace with OrchestraException from Ale fork when merging
             raise Exception(f"A cycle was found in the dependency graph: {e.args[1]}. This should never happen.")
 
         if not self._toposorter.is_active():
@@ -110,7 +109,6 @@ class Executor:
         # Find an assignment for all the choices so the graph becomes acyclic
         dependency_graph = self._assign_choices(dependency_graph)
         if dependency_graph is None:
-            # TODO: replace with OrchestraException from Ale fork when merging
             raise Exception("Could not find an acyclic assignment for the given dependency graph")
 
         if remove_unreachable:
@@ -331,8 +329,8 @@ class Executor:
         for component, group in groups_by_component.items():
             dependency_graph = self._try_group_orders(dependency_graph, group)
             if dependency_graph is None:
-                raise OrchestraException(f"Could not enforce an order between actions "
-                                         f"of component {component} pertaining to multiple builds")
+                raise Exception(f"Could not enforce an order between actions of "
+                                f"component {component} pertaining to multiple builds")
 
         return dependency_graph
 


### PR DESCRIPTION
This PR solves an edge-case emerging with rev.ng orchestra configuration, which causes orchestra to install `libc@headers` after `libc@default` (in turn causing gcc build failures).
It occurred when:
- requesting to build from source `gcc@stage2` and `gcc@stage1`
- binary archives are available for `libc@default`

Causing the following dependency graph:
![image](https://user-images.githubusercontent.com/7656022/103924711-b7d12700-5116-11eb-9ede-2656c2d8dc9f.png)

Since `libc@default` (`musl@default`) is installed from binary archives, its build dependency on gcc is pruned. This causes it to be independent from the `gcc@stage1` part of the graph, which contains `libc@headers`.

The workaround is applied on the solved graph and works as follows.

It ensures that when two builds of the same component are scheduled to be installed their direct antidependencies will find those exact builds when run.
Example:
```
       +-------+
    +--+  A@1  +--+
    |  +-------+  |
+---v---+     +---v---+
|  B@1  |     |  A@2  +--+
+-------+     +-------+  |
                     +---v---+
                     |  B@2  |
                     +-------+
```

The following schedules are both acceptable:
    - B@2, A@2, B@1, A@1
    - B@2, B@1, A@2, A@1

However the second schedule runs B@1 after B@2, but A@2 after B@1, so A@2 would not find the exact build it was expecting (replace A with gcc and B with libc in the rev.ng scenario).

The pass transforms the graph above into:

```
       +-------+
    +--+  A@1  +--+
    |  +-------+  |
+---v---+     +---v---+
|  B@1  +----->  A@2  +--+
+---+---+     +-------+  |
    |                +---v---+
    +---------------->  B@2  |
                     +-------+
```

For each component C the algorithm creates a list of groups of actions, one for each build.
Each group contains:
 1. actions that pertain to a specific build of the component
 2. actions that directly depend on actions of point 1

The algorithm tries all possible permutations of the groups in the list.
For each permutation [G1, G2, ..., Gn] all actions in group Gi are marked to depend on all actions in group Gi+1.
The graph is checked for cycles and if none are found the order is accepted.
