### PR TITLE
Reintroduce --no-force

### DIFF
--- a/orchestra/cmds/configure.py
+++ b/orchestra/cmds/configure.py
@@ -28,7 +28,7 @@ def handle_configure(args):
         logger.error(f"Component {args.component} not found! Did you mean {suggested_component_name}?")
         return 1
 
-    executor = Executor(args, [build.configure], no_deps=args.no_deps)
+    executor = Executor(args, [build.configure], no_deps=args.no_deps, no_force=args.no_force)
     failed = executor.run()
     exitcode = 1 if failed else 0
     return exitcode

--- a/orchestra/cmds/graph.py
+++ b/orchestra/cmds/graph.py
@@ -27,6 +27,8 @@ def install_subcommand(sub_argparser):
                             help="Don't remove satisfied leaves")
     cmd_parser.add_argument("--no-transitive-reduction", action="store_true",
                             help="Don't perform transitive reduction")
+    cmd_parser.add_argument("--no-force", action="store_true",
+                            help="Don't force execution of the root action")
 
 
 def handle_graph(args):
@@ -52,7 +54,7 @@ def handle_graph(args):
             else:
                 actions.add(component.default_build.install)
 
-    executor = Executor(args, actions)
+    executor = Executor(args, actions, no_force=args.no_force)
 
     if not args.solved:
         graph = executor._create_initial_dependency_graph()

--- a/orchestra/cmds/install.py
+++ b/orchestra/cmds/install.py
@@ -17,6 +17,7 @@ def install_subcommand(sub_argparser):
     cmd_parser.add_argument("--create-binary-archives", action="store_true", help="Create binary archives")
     cmd_parser.add_argument("--keep-tmproot", action="store_true", help="Do not remove temporary root directories")
     cmd_parser.add_argument("--test", action="store_true", help="Run the test suite")
+    cmd_parser.add_argument("--no-force", action="store_true", help="Don't force execution of the root action")
 
 
 def handle_install(args):
@@ -31,7 +32,7 @@ def handle_install(args):
         logger.error(f"Component {args.component} not found! Did you mean {suggested_component_name}?")
         return 1
 
-    executor = Executor(args, [build.install], no_deps=args.no_deps)
+    executor = Executor(args, [build.install], no_deps=args.no_deps, no_force=args.no_force)
     failed = executor.run()
     exitcode = 1 if failed else 0
     return exitcode

--- a/orchestra/executor.py
+++ b/orchestra/executor.py
@@ -15,10 +15,11 @@ from .util import set_terminal_title, OrchestraException
 
 
 class Executor:
-    def __init__(self, args, actions, no_deps=False, threads=1):
+    def __init__(self, args, actions, no_deps=False, no_force=False, threads=1):
         self.args = args
         self.actions = actions
         self.no_deps = no_deps
+        self.no_force = no_force
         self.threads = 1
 
         self._toposorter = graphlib.TopologicalSorter()
@@ -124,7 +125,8 @@ class Executor:
         if remove_satisfied:
             self._remove_satisfied_attracting_components(dependency_graph)
             # Re-add the true root actions as they may have been removed
-            dependency_graph.add_nodes_from(true_roots)
+            if not self.no_force:
+                dependency_graph.add_nodes_from(true_roots)
 
         if transitive_reduction:
             dependency_graph = self._transitive_reduction(dependency_graph)


### PR DESCRIPTION
This PR reintroduces the `--no-force` switch for `orc install`, which was removed when reworking the scheduling algorithm.
This switch tells orchestra not to force execution of the action specified by the user.
E.g. if `mycomponent` (and its dependencies) is already installed and up-to-date, `orc install --no-force mycomponent` would not do anything.