### PR TITLE
Implement upgrade and improve update

### DIFF
--- a/orchestra/actions/action.py
+++ b/orchestra/actions/action.py
@@ -17,12 +17,12 @@ class Action:
         self._explicit_dependencies: Set[Action] = set()
         self._script = script
 
-    def run(self, args):
+    def run(self, cmdline_args, *args, **kwargs):
         logger.info(f"Executing {self}")
-        if not args.pretend:
-            self._run(args)
+        if not cmdline_args.pretend:
+            self._run(cmdline_args, *args, **kwargs)
 
-    def _run(self, args):
+    def _run(self, cmdline_args):
         """Executes the action"""
         self._run_user_script(self.script)
 

--- a/orchestra/actions/configure.py
+++ b/orchestra/actions/configure.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 import os
+from pathlib import Path
 
 from loguru import logger
 
@@ -14,7 +14,7 @@ class ConfigureAction(ActionForBuild):
         # TODO: invalidate configure if self_hash (or even recursive_hash?) has changed
         return os.path.exists(self._configure_successful_path)
 
-    def _run(self, args):
+    def _run(self, cmdline_args):
         if os.path.exists(self._configure_successful_path):
             logger.warning("This component was already successfully configured, rerunning configure script")
             os.remove(self._configure_successful_path)

--- a/orchestra/actions/install.py
+++ b/orchestra/actions/install.py
@@ -47,7 +47,7 @@ class InstallAction(ActionForBuild):
         pre_file_list = self._index_directory(tmp_root + orchestra_root, relative_to=tmp_root + orchestra_root)
 
         install_start_time = time.time()
-        if self.allow_binary_archive and self._binary_archive_exists():
+        if self.allow_binary_archive and self.binary_archive_exists():
             self._install_from_binary_archive(args)
             source = "binary archives"
         elif self.allow_build:
@@ -141,7 +141,7 @@ class InstallAction(ActionForBuild):
         git_lfs.fetch(binary_archive_repo_dir, only=[os.path.realpath(binary_archive_path)])
 
     def _extract_binary_archive(self):
-        if not self._binary_archive_exists():
+        if not self.binary_archive_exists():
             raise Exception("Binary archive not found!")
 
         archive_filepath = self._binary_archive_filepath()
@@ -153,7 +153,7 @@ class InstallAction(ActionForBuild):
         self._run_internal_script(script)
 
     def _implicit_dependencies(self):
-        if self.allow_binary_archive and self._binary_archive_exists() or not self.allow_build:
+        if self.allow_binary_archive and self.binary_archive_exists() or not self.allow_build:
             return set()
         else:
             return {self.build.configure}
@@ -389,7 +389,7 @@ class InstallAction(ActionForBuild):
                 return try_archive_path
         return None
 
-    def _binary_archive_exists(self):
+    def binary_archive_exists(self):
         return self._binary_archive_filepath() is not None
 
     @property

--- a/orchestra/actions/install.py
+++ b/orchestra/actions/install.py
@@ -37,7 +37,7 @@ class InstallAction(ActionForBuild):
         self.allow_binary_archive = allow_binary_archive
         self.create_binary_archive = create_binary_archive
 
-    def _run(self, args):
+    def _run(self, cmdline_args, set_manually_installed=False):
         tmp_root = self.environment["TMP_ROOT"]
         orchestra_root = self.environment['ORCHESTRA_ROOT']
 
@@ -48,10 +48,10 @@ class InstallAction(ActionForBuild):
 
         install_start_time = time.time()
         if self.allow_binary_archive and self.binary_archive_exists():
-            self._install_from_binary_archive(args)
+            self._install_from_binary_archive()
             source = "binary archives"
         elif self.allow_build:
-            self._build_and_install(args)
+            self._build_and_install(cmdline_args)
             if self.create_binary_archive:
                 self._create_binary_archive()
             source = "build"
@@ -70,7 +70,7 @@ class InstallAction(ActionForBuild):
             os.path.relpath(self.config.installed_component_metadata_path(self.build.component.name), orchestra_root))
         new_files = [f for f in post_file_list if f not in pre_file_list]
 
-        if not args.no_merge:
+        if not cmdline_args.no_merge:
             if is_installed(self.config, self.build.component.name):
                 logger.info("Uninstalling previously installed build")
                 uninstall(self.build.component.name, self.config)
@@ -78,27 +78,51 @@ class InstallAction(ActionForBuild):
             logger.info("Merging installed files into orchestra root directory")
             self._merge()
 
-            # Write file metadata and index
-            os.makedirs(self.config.installed_component_metadata_dir(), exist_ok=True)
-            metadata = {
-                "component_name": self.build.component.name,
-                "build_name": self.build.name,
-                "install_time": install_end_time - install_start_time,
-                "source": source,
-                "self_hash": self.build.component.self_hash,
-                "recursive_hash": self.build.component.recursive_hash,
-                "binary_archive_path": os.path.join(self.build.binary_archive_dir, self.build.binary_archive_filename),
-            }
-            with open(self.config.installed_component_metadata_path(self.build.component.name), "w") as f:
-                json.dump(metadata, f)
+            self._update_metadata(new_files,
+                                  install_end_time - install_start_time,
+                                  source,
+                                  set_manually_installed)
 
-            with open(self.config.installed_component_file_list_path(self.build.component.name), "w") as f:
-                new_files = [f"{f}\n" for f in new_files]
-                f.writelines(new_files)
-
-        if not args.keep_tmproot:
+        if not cmdline_args.keep_tmproot:
             logger.info("Cleaning up tmproot")
             self._cleanup_tmproot()
+
+    def _update_metadata(self, file_list, install_time, source, set_manually_insalled):
+        # Write file metadata and index
+        metadata_dir_path = self.config.installed_component_metadata_dir()
+        metadata_path = self.config.installed_component_metadata_path(self.build.component.name)
+        file_list_path = self.config.installed_component_file_list_path(self.build.component.name)
+
+        os.makedirs(metadata_dir_path, exist_ok=True)
+
+        if os.path.exists(metadata_path):
+            with open(metadata_path) as f:
+                metadata = json.load(f)
+        else:
+            metadata = {}
+
+        binary_archive_path = os.path.join(self.build.binary_archive_dir, self.build.binary_archive_filename)
+        manually_installed = metadata.get("manually_installed", False) or set_manually_insalled
+
+        metadata.update({
+            "component_name": self.build.component.name,
+            "build_name": self.build.name,
+            "install_time": install_time,
+            "source": source,
+            "self_hash": self.build.component.self_hash,
+            "recursive_hash": self.build.component.recursive_hash,
+            "binary_archive_path": binary_archive_path,
+            "manually_installed": manually_installed,
+        })
+
+        # Write metadata
+        with open(metadata_path, "w") as f:
+            json.dump(metadata, f)
+
+        # Write installed file list (.idx)
+        with open(file_list_path, "w") as f:
+            new_files = [f"{f}\n" for f in file_list]
+            f.writelines(new_files)
 
     def _prepare_tmproot(self):
         script = dedent("""
@@ -116,7 +140,7 @@ class InstallAction(ActionForBuild):
             """)
         self._run_internal_script(script)
 
-    def _install_from_binary_archive(self, args):
+    def _install_from_binary_archive(self):
         # TODO: handle nonexisting binary archives
         logger.info("Fetching binary archive")
         self._fetch_binary_archive()

--- a/orchestra/cmds/clone.py
+++ b/orchestra/cmds/clone.py
@@ -25,7 +25,7 @@ def handle_clone(args):
         return 1
 
     if not build.component.clone:
-        print("This component does not have a git repository configured!")
+        logger.error("This component does not have a git repository configured!")
         return 1
 
     executor = Executor(args, [build.component.clone], no_force=args.no_force)

--- a/orchestra/cmds/clone.py
+++ b/orchestra/cmds/clone.py
@@ -12,6 +12,7 @@ def install_subcommand(sub_argparser):
                                           parents=[execution_options],
                                           )
     cmd_parser.add_argument("component", help="Name of the component to clone")
+    cmd_parser.add_argument("--no-force", action="store_true", help="Don't force execution of the root action")
 
 
 def handle_clone(args):
@@ -27,7 +28,7 @@ def handle_clone(args):
         print("This component does not have a git repository configured!")
         return 1
 
-    executor = Executor(args, [build.component.clone])
+    executor = Executor(args, [build.component.clone], no_force=args.no_force)
     failed = executor.run()
     exitcode = 1 if failed else 0
     return exitcode

--- a/orchestra/cmds/configure.py
+++ b/orchestra/cmds/configure.py
@@ -28,7 +28,7 @@ def handle_configure(args):
         logger.error(f"Component {args.component} not found! Did you mean {suggested_component_name}?")
         return 1
 
-    executor = Executor(args, [build.configure], no_deps=args.no_deps)
+    executor = Executor(args, [build.configure], no_deps=args.no_deps, no_force=args.no_force)
     failed = executor.run()
     exitcode = 1 if failed else 0
     return exitcode

--- a/orchestra/cmds/graph.py
+++ b/orchestra/cmds/graph.py
@@ -27,6 +27,8 @@ def install_subcommand(sub_argparser):
                             help="Don't remove satisfied leaves")
     cmd_parser.add_argument("--no-transitive-reduction", action="store_true",
                             help="Don't perform transitive reduction")
+    cmd_parser.add_argument("--no-force", action="store_true",
+                            help="Don't force execution of the root action")
 
 
 def handle_graph(args):
@@ -52,7 +54,7 @@ def handle_graph(args):
             else:
                 actions.add(component.default_build.install)
 
-    executor = Executor(args, actions)
+    executor = Executor(args, actions, no_force=args.no_force)
 
     if not args.solved:
         graph = executor._create_initial_dependency_graph()

--- a/orchestra/cmds/install.py
+++ b/orchestra/cmds/install.py
@@ -17,6 +17,7 @@ def install_subcommand(sub_argparser):
     cmd_parser.add_argument("--create-binary-archives", action="store_true", help="Create binary archives")
     cmd_parser.add_argument("--keep-tmproot", action="store_true", help="Do not remove temporary root directories")
     cmd_parser.add_argument("--test", action="store_true", help="Run the test suite")
+    cmd_parser.add_argument("--no-force", action="store_true", help="Don't force execution of the root action")
 
 
 def handle_install(args):
@@ -32,7 +33,7 @@ def handle_install(args):
         logger.error(f"Component {args.component} not found! Did you mean {suggested_component_name}?")
         return 1
 
-    executor = Executor(args, [build.install], no_deps=args.no_deps)
+    executor = Executor(args, [build.install], no_deps=args.no_deps, no_force=args.no_force)
     failed = executor.run()
     exitcode = 1 if failed else 0
     return exitcode

--- a/orchestra/cmds/main.py
+++ b/orchestra/cmds/main.py
@@ -6,13 +6,14 @@ from . import components
 from . import configure
 from . import dumpconfig
 from . import environment
+from . import fix_binary_archives_symlinks
 from . import graph
 from . import install
+from . import ls
 from . import shell
 from . import uninstall
 from . import update
-from . import ls
-from . import fix_binary_archives_symlinks
+from . import upgrade
 
 
 class CustomArgumentParser(argparse.ArgumentParser):
@@ -38,15 +39,16 @@ main_subparsers = main_parser.add_subparsers(
     parser_class=CustomArgumentParser,
 )
 components.install_subcommand(main_subparsers)
-dumpconfig.install_subcommand(main_subparsers)
 environment.install_subcommand(main_subparsers)
 clone.install_subcommand(main_subparsers)
-update.install_subcommand(main_subparsers)
 configure.install_subcommand(main_subparsers)
 install.install_subcommand(main_subparsers)
-clean.install_subcommand(main_subparsers)
 uninstall.install_subcommand(main_subparsers)
+clean.install_subcommand(main_subparsers)
+update.install_subcommand(main_subparsers)
+upgrade.install_subcommand(main_subparsers)
 graph.install_subcommand(main_subparsers)
 shell.install_subcommand(main_subparsers)
 ls.install_subcommand(main_subparsers)
 fix_binary_archives_symlinks.install_subcommand(main_subparsers)
+dumpconfig.install_subcommand(main_subparsers)

--- a/orchestra/cmds/main.py
+++ b/orchestra/cmds/main.py
@@ -38,17 +38,23 @@ main_subparsers = main_parser.add_subparsers(
     dest="command_name",
     parser_class=CustomArgumentParser,
 )
-components.install_subcommand(main_subparsers)
-environment.install_subcommand(main_subparsers)
-clone.install_subcommand(main_subparsers)
-configure.install_subcommand(main_subparsers)
-install.install_subcommand(main_subparsers)
-uninstall.install_subcommand(main_subparsers)
-clean.install_subcommand(main_subparsers)
-update.install_subcommand(main_subparsers)
-upgrade.install_subcommand(main_subparsers)
-graph.install_subcommand(main_subparsers)
-shell.install_subcommand(main_subparsers)
-ls.install_subcommand(main_subparsers)
-fix_binary_archives_symlinks.install_subcommand(main_subparsers)
-dumpconfig.install_subcommand(main_subparsers)
+
+subcommands = [
+    components,
+    environment,
+    clone,
+    configure,
+    install,
+    uninstall,
+    clean,
+    update,
+    upgrade,
+    graph,
+    shell,
+    ls,
+    fix_binary_archives_symlinks,
+    dumpconfig,
+]
+
+for cmd in subcommands:
+    cmd.install_subcommand(main_subparsers)

--- a/orchestra/cmds/update.py
+++ b/orchestra/cmds/update.py
@@ -78,8 +78,9 @@ def handle_update(args):
                 failed_pulls.append(f"Repository {component.name}")
 
     if failed_pulls:
-        formatted_failed_pulls = "\n".join([f"  {repo}" for repo in failed_pulls])
-        failed_git_pull_suggestion = dedent(f"""
+        formatted_failed_pulls = "\n".join([f"  - {repo}" for repo in failed_pulls])
+        # Note: f-strings don't account for indentation, using a template is more practical
+        failed_git_pull_template = dedent("""
         Could not git pull --ff-only the following repositories:
         {formatted_failed_pulls}
 
@@ -89,11 +90,13 @@ def handle_update(args):
             - `git pull --rebase`, to pull remote changes and apply your commits on top
             - `git push` your changes to the remotes
         """)
+        failed_git_pull_suggestion = failed_git_pull_template.format(formatted_failed_pulls=formatted_failed_pulls)
         logger.error(failed_git_pull_suggestion)
 
     if failed_clones:
-        formatted_failed_clones = "\n".join([f"  {repo}" for repo in failed_clones])
-        failed_git_clone_suggestion = dedent(f"""
+        formatted_failed_clones = "\n".join([f"  - {repo}" for repo in failed_clones])
+        # Note: f-strings don't account for indentation, using a template is more practical
+        failed_git_clone_template = dedent("""
                 Could not clone the following repositories:
                 {formatted_failed_clones}
 
@@ -101,6 +104,7 @@ def handle_update(args):
                     - check your network connection
                     - check your ssh and git configuration (try manually cloning the repositories)
                 """)
+        failed_git_clone_suggestion = failed_git_clone_template.format(formatted_failed_clones=formatted_failed_clones)
         logger.error(failed_git_clone_suggestion)
 
     if failed_pulls or failed_clones:

--- a/orchestra/cmds/update.py
+++ b/orchestra/cmds/update.py
@@ -70,10 +70,13 @@ def handle_update(args):
         progress_bar = tqdm(to_pull, unit="components")
         for component in progress_bar:
             source_path = os.path.join(config.sources_dir, component.name)
-            assert is_git_repo_root(source_path)
-
             logger.debug(f"Pulling {component.name}")
             progress_bar.set_postfix_str(f"{component.name}")
+
+            if not is_git_repo_root(source_path):
+                failed_pulls.append(f"Repository {component.name}: Directory {source_path} is not a git repo")
+                continue
+
             if not git_pull(source_path):
                 failed_pulls.append(f"Repository {component.name}")
 

--- a/orchestra/cmds/upgrade.py
+++ b/orchestra/cmds/upgrade.py
@@ -1,0 +1,35 @@
+from .common import execution_options
+from ..executor import Executor
+from ..model.configuration import Configuration
+from ..util import get_installed_metadata
+
+
+def install_subcommand(sub_argparser):
+    cmd_parser = sub_argparser.add_parser("upgrade",
+                                          handler=handle_upgrade,
+                                          help="Upgrade all manually installed components",
+                                          parents=[execution_options],
+                                          )
+    cmd_parser.add_argument("--test", action="store_true", help="Run the test suite")
+
+
+def handle_upgrade(args):
+    config = Configuration(use_config_cache=args.config_cache)
+
+    install_actions = set()
+
+    for component_name, component in config.components.items():
+        metadata = get_installed_metadata(component_name, config)
+        if metadata is None:
+            continue
+
+        if metadata.get("manually_installed", False):
+            installed_build_name = metadata["build_name"]
+            install_actions.add(component.builds[installed_build_name].install)
+
+    args.keep_tmproot = False
+    args.no_merge = False
+    executor = Executor(args, install_actions, no_force=True)
+    failed = executor.run()
+    exitcode = 1 if failed else 0
+    return exitcode

--- a/orchestra/executor.py
+++ b/orchestra/executor.py
@@ -404,8 +404,12 @@ class Executor:
     def _run_action(self, action: Action):
         self._running_actions.append(action)
         self._current_remaining -= 1
+        kwargs = {}
+        if isinstance(action, InstallAction):
+            kwargs["set_manually_installed"] = action in self.actions
+
         try:
-            return action.run(args=self.args)
+            return action.run(cmdline_args=self.args, **kwargs)
         finally:
             self._running_actions.remove(action)
 

--- a/orchestra/executor.py
+++ b/orchestra/executor.py
@@ -17,10 +17,11 @@ from .util import set_terminal_title, OrchestraException
 
 
 class Executor:
-    def __init__(self, args, actions, no_deps=False, threads=1):
+    def __init__(self, args, actions, no_deps=False, no_force=False, threads=1):
         self.args = args
         self.actions = actions
         self.no_deps = no_deps
+        self.no_force = no_force
         self.threads = 1
 
         self._toposorter = graphlib.TopologicalSorter()
@@ -127,7 +128,8 @@ class Executor:
         if remove_satisfied:
             self._remove_satisfied_attracting_components(dependency_graph)
             # Re-add the true root actions as they may have been removed
-            dependency_graph.add_nodes_from(true_roots)
+            if not self.no_force:
+                dependency_graph.add_nodes_from(true_roots)
 
         if intra_component_ordering:
             dependency_graph = self._enforce_intra_component_ordering(dependency_graph)

--- a/orchestra/model/configuration.py
+++ b/orchestra/model/configuration.py
@@ -15,7 +15,8 @@ from loguru import logger
 from . import build as bld
 from . import component as comp
 from ..actions import CloneAction, ConfigureAction, InstallAction, AnyOfAction
-from ..actions.util import get_script_output, try_run_internal_subprocess, get_subprocess_output
+from ..actions.util import get_script_output, get_subprocess_output
+from ..actions.util import try_run_internal_subprocess, try_get_subprocess_output
 from ..util import parse_component_name, parse_dependency
 
 
@@ -315,7 +316,7 @@ class Configuration:
         logger.info("Populating default remotes for repositories and binary archives")
         logger.info("Remember to run `orc update` next")
 
-        git_output = get_subprocess_output(
+        git_output = try_get_subprocess_output(
             ["git", "-C", self.orchestra_dotdir, "config", "--get-regexp", r"remote\.[^.]*\.url"]
         )
         remotes_re = re.compile(r"remote\.(?P<name>[^.]*)\.url (?P<url>.*)$")


### PR DESCRIPTION
This PR:

* addresses issue #8 (improvements to `orc update`)
* implements the `orchestra upgrade` command
* reintroduces the `--no-force` switch for `orc install`

## Issue #8 (improvements to `orc update`)

* [x] Discard any changes made to binary archives and reset them to master. Users are not supposed to create archives. They should expected them to be discarded.
* [x] git pull output should not be shown
* [x] Indentation needs to be fixed. It now looks like this:
  ```
        Could not git pull --ff-only the following repositories:
          Repository llvm
  Repository revng
  Repository revng-c
  ```
* [x] If a component is built from source, not being able to update should be reported but it should not trigger an error.
* [x] We need a --reinstall flag that reinstalls all the installed packages. Maybe we should make a command orc upgrade (mimicking the apt parlance).
* [ ] Not strictly related to updates, but when a binary archive is not found we should output a diagnostic message saying what binary archives are available and what are the commit and recursive hashes we were looking for

## `orc upgrade`

This command reinstalls all the components that were installed manually and their dependencies, if needed.

## `orc install --no-force`

The switch was removed when reworking the scheduling algorithm. It tells orchestra not to force execution of the action specified by the user.
E.g. if mycomponent (and its dependencies) is already installed and up-to-date, orc install --no-force mycomponent would not do anything.