### PR TITLE
Use xz as compressor for binary archives

### DIFF
--- a/test/binary_archives/test_binary_archives.py
+++ b/test/binary_archives/test_binary_archives.py
@@ -17,7 +17,7 @@ def test_binary_archive_location(orchestra: OrchestraShim):
     if commit is None:
         commit = "none"
 
-    expected_filename = f"{commit}_{component.recursive_hash}.tar.gz"
+    expected_filename = f"{commit}_{component.recursive_hash}.tar.xz"
     expected_relative_path = f"{action.architecture}/{component.name}/{build.name}/{expected_filename}"
     assert action.binary_archive_filename == expected_filename
     assert action.binary_archive_relative_path == expected_relative_path


### PR DESCRIPTION
With this PR binary archives are compressed using XZ.
I added code to accept all `<archivename>.tar.<compressor>` when installing, so it should not disrupt existing archives.