### PR TITLE
orc binary-archives command (including clean support)

### DIFF
--- a/orchestra/actions/action.py
+++ b/orchestra/actions/action.py
@@ -87,20 +87,20 @@ class Action:
     def __repr__(self):
         return self.__str__()
 
-    def _run_user_script(self, script):
-        run_user_script(script, environment=self.environment)
+    def _run_user_script(self, script, cwd=None):
+        run_user_script(script, environment=self.environment, cwd=cwd)
 
-    def _run_internal_script(self, script):
-        run_internal_script(script, environment=self.environment)
+    def _run_internal_script(self, script, cwd=None):
+        run_internal_script(script, environment=self.environment, cwd=cwd)
 
-    def _try_run_internal_script(self, script):
-        return try_run_internal_script(script, environment=self.environment)
+    def _try_run_internal_script(self, script, cwd=None):
+        return try_run_internal_script(script, environment=self.environment, cwd=cwd)
 
-    def _get_script_output(self, script):
-        return get_script_output(script, environment=self.environment)
+    def _get_script_output(self, script, cwd=None):
+        return get_script_output(script, environment=self.environment, cwd=cwd)
 
-    def _try_get_script_output(self, script):
-        return try_get_script_output(script, environment=self.environment)
+    def _try_get_script_output(self, script, cwd=None):
+        return try_get_script_output(script, environment=self.environment, cwd=cwd)
 
 
 class ActionForComponent(Action):

--- a/orchestra/actions/util/__init__.py
+++ b/orchestra/actions/util/__init__.py
@@ -7,52 +7,57 @@ from .impl import _run_internal_subprocess
 from .impl import _run_user_script
 
 
-def run_internal_script(script, environment: OrderedDict = None):
+def run_internal_script(script, environment: OrderedDict = None, cwd=None):
     """Helper for running internal scripts.
     If the script returns a nonzero exit code an error is logged and an OrchestraException is raised.
     :param script: the script to run
     :param environment: optional additional environment variables
+    :param cwd: if not None, the command is executed in the specified path
     """
-    _run_internal_script(script, environment=environment, check_returncode=True)
+    _run_internal_script(script, environment=environment, check_returncode=True, cwd=cwd)
 
 
-def try_run_internal_script(script, environment: OrderedDict = None):
+def try_run_internal_script(script, environment: OrderedDict = None, cwd=None):
     """Helper for running internal scripts that might fail.
     :param script: the script to run
     :param environment: optional additional environment variables
+    :param cwd: if not None, the command is executed in the specified path
     :returns: the exit code of the script
     """
-    return _run_internal_script(script, environment=environment, check_returncode=False)
+    return _run_internal_script(script, environment=environment, check_returncode=False, cwd=cwd)
 
 
-def run_user_script(script, environment: OrderedDict = None):
+def run_user_script(script, environment: OrderedDict = None, cwd=None):
     """Helper for running user scripts.
     If the script returns a nonzero exit code an OrchestraException is raised.
     :param script: the script to run
     :param environment: optional additional environment variables
+    :param cwd: if not None, the command is executed in the specified path
     """
-    _run_user_script(script, environment=environment, check_returncode=True)
+    _run_user_script(script, environment=environment, check_returncode=True, cwd=cwd)
 
 
-def get_script_output(script, environment: OrderedDict = None, decode_as="utf-8"):
+def get_script_output(script, environment: OrderedDict = None, decode_as="utf-8", cwd=None):
     """Helper for getting stdout of a script.
     If the script returns a nonzero exit code an error is logged and an OrchestraException is raised.
     :param script: the script to run
     :param environment: optional additional environment variables
     :param decode_as: decode the script output using this encoding
+    :param cwd: if not None, the command is executed in the specified path
     :return: the stdout produced by the script
     """
-    return _get_script_output(script, environment=environment, check_returncode=True, decode_as=decode_as)
+    return _get_script_output(script, environment=environment, check_returncode=True, decode_as=decode_as, cwd=cwd)
 
 
-def try_get_script_output(script, environment: OrderedDict = None, decode_as="utf-8"):
+def try_get_script_output(script, environment: OrderedDict = None, decode_as="utf-8", cwd=None):
     """Helper for getting stdout of a script that might fail.
     :param script: the script to run
     :param environment: optional additional environment variables
     :param decode_as: decode the script output using this encoding
+    :param cwd: if not None, the command is executed in the specified path
     :return: the stdout produced by the script or None if the script exits with a nonzero exit code
     """
-    return _get_script_output(script, environment=environment, check_returncode=False, decode_as=decode_as)
+    return _get_script_output(script, environment=environment, check_returncode=False, decode_as=decode_as, cwd=cwd)
 
 
 def run_internal_subprocess(

--- a/orchestra/actions/util/impl.py
+++ b/orchestra/actions/util/impl.py
@@ -46,12 +46,13 @@ def _run_script(
     return subprocess.run(["/bin/bash", "-c", script_to_run], stdout=stdout, stderr=stderr, cwd=cwd)
 
 
-def _run_internal_script(script, environment: OrderedDict = None, check_returncode=True):
+def _run_internal_script(script, environment: OrderedDict = None, check_returncode=True, cwd=None):
     """Helper for running internal scripts.
     :param script: the script to run
     :param environment: optional additional environment variables
     :param check_returncode: if True, log an error and raise an OrchestraException
                              when the script returns a nonzero exit code
+    :param cwd: if not None, the command is executed in the specified path
     :returns: the exit code of the script
     """
     result = _run_script(
@@ -60,6 +61,7 @@ def _run_internal_script(script, environment: OrderedDict = None, check_returnco
         loglevel="DEBUG",
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
+        cwd=cwd,
     )
 
     if check_returncode and result.returncode != 0:
@@ -74,12 +76,13 @@ def _run_internal_script(script, environment: OrderedDict = None, check_returnco
     return result.returncode
 
 
-def _run_user_script(script, environment: OrderedDict = None, check_returncode=True):
+def _run_user_script(script, environment: OrderedDict = None, check_returncode=True, cwd=None):
     """Helper for running user scripts
     :param script: the script to run
     :param environment: optional additional environment variables
     :param check_returncode: if True, log an error and raise an OrchestraException
                              when the script returns a nonzero exit code
+    :param cwd: if not None, the command is executed in the specified path
     """
 
     quiet = globals.loglevel not in ["TRACE", "DEBUG", "INFO"]
@@ -96,6 +99,7 @@ def _run_user_script(script, environment: OrderedDict = None, check_returncode=T
         loglevel="INFO",
         stdout=stdout,
         stderr=stderr,
+        cwd=cwd,
     )
 
     if check_returncode and result.returncode != 0:
@@ -111,7 +115,8 @@ def _get_script_output(
         script,
         environment: OrderedDict = None,
         check_returncode=True,
-        decode_as="utf-8"
+        decode_as="utf-8",
+        cwd=None,
 ):
     """Helper for getting stdout of a script
     :param script: the script to run
@@ -119,6 +124,7 @@ def _get_script_output(
     :param check_returncode: if True, log an error and raise an OrchestraException
                              when the script returns a nonzero exit code
     :param decode_as: decode the script output using this encoding
+    :param cwd: if not None, the command is executed in the specified path
     :return: the stdout produced by the script or None if the script exits with a nonzero exit code
     """
     result = _run_script(
@@ -127,6 +133,7 @@ def _get_script_output(
         loglevel="DEBUG",
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        cwd=cwd,
     )
 
     if check_returncode and result.returncode != 0:

--- a/orchestra/cmds/__init__.py
+++ b/orchestra/cmds/__init__.py
@@ -1,0 +1,9 @@
+import argparse
+
+
+class CustomArgumentParser(argparse.ArgumentParser):
+    def __init__(self, handler=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not handler:
+            raise ValueError("Please provide a command handler")
+        self.handler = handler

--- a/orchestra/cmds/binary_archives.py
+++ b/orchestra/cmds/binary_archives.py
@@ -1,0 +1,104 @@
+import os
+
+from loguru import logger
+
+from . import CustomArgumentParser
+from .fix_binary_archives_symlinks import handle_fix_binary_archives_symlinks
+from .ls import handle_ls
+from ..actions.util import get_script_output
+from ..gitutils import is_root_of_git_repo
+from ..model.configuration import Configuration
+
+_cmd_parser = None
+_subcmd_parser = None
+
+
+def install_subcommand(sub_argparser):
+    global _cmd_parser, _subcmd_parser
+    _cmd_parser = sub_argparser.add_parser("binary-archives",
+                                           handler=_handle_archives_top_level,
+                                           help="Manipulate binary archives")
+    _subcmd_parser = _cmd_parser.add_subparsers(
+        description="Available subcommands. Use <subcommand> --help",
+        dest="archives_command_name",
+        parser_class=CustomArgumentParser,
+        metavar="<subcommand>",
+    )
+
+    _subcmd_parser.add_parser(
+        "ls",
+        handler=handle_ls,
+        help="Print binary archives directories",
+    )
+
+    _subcmd_parser.add_parser(
+        "fix-symlinks",
+        handler=handle_fix_binary_archives_symlinks,
+        help="Fix symlinks in binary archives",
+    )
+
+    clean_subcmd = _subcmd_parser.add_parser(
+        "clean",
+        handler=handle_clean,
+        help="Delete stale binary archives"
+    )
+    clean_subcmd.add_argument(
+        "--pretend",
+        action="store_true",
+        help="Only print what would be done. Deleted files are printed at DEBUG loglevel"
+    )
+
+
+def _handle_archives_top_level(args):
+    global _subcmd_parser
+    subcommand_parser = _subcmd_parser.choices.get(args.archives_command_name)
+    if subcommand_parser is None:
+        _cmd_parser.print_help()
+        exit(1)
+
+    subcommand_parser.handler(args)
+
+
+def handle_clean(args):
+    config = Configuration(use_config_cache=args.config_cache)
+    for name in config.binary_archives_remotes.keys():
+        path = os.path.join(config.binary_archives_dir, name)
+        if is_root_of_git_repo(path):
+            logger.info(f"Cleaning binary archive {name}")
+            unneeded_files = find_unreferenced_archives(path)
+
+            for file in unneeded_files:
+                abspath = os.path.join(path, file)
+                if os.path.exists(abspath):
+                    logger.debug(f"Deleting {file}")
+                    if not args.pretend:
+                        os.unlink(abspath)
+
+        elif os.path.exists(path):
+            logger.warning(f"Path {path} is not the root of a git repository, skipping")
+
+
+def find_unreferenced_archives(binary_archive_path):
+    """Finds archives tracked by git-lfs but not referenced by any symlink
+    :param binary_archive_path: path to the binary archive git lfs repository
+    :return: a set of paths of the unreferenced files. The paths are relative to binary_archive_path.
+    """
+
+    all_tracked_files = set(
+        get_script_output(f"git lfs ls-files -n", cwd=binary_archive_path).splitlines()
+    )
+
+    files_still_linked = set()
+    for dirpath, dirnames, filenames in os.walk(binary_archive_path):
+        for filename in filenames:
+            filepath = os.path.join(dirpath, filename)
+            if os.path.islink(filepath):
+                link_dst = os.readlink(filepath)
+                if os.path.isabs(link_dst):
+                    logger.warning(f"Symlink {filepath} points to absolute path {link_dst}")
+                else:
+                    absolute_link_dst = os.path.realpath(os.path.join(dirpath, link_dst))
+                    relative_link_dst = os.path.relpath(absolute_link_dst, binary_archive_path)
+                    files_still_linked.add(relative_link_dst)
+
+    return all_tracked_files - files_still_linked

--- a/orchestra/cmds/main.py
+++ b/orchestra/cmds/main.py
@@ -1,5 +1,6 @@
 import argparse
 
+from . import CustomArgumentParser
 from . import clean
 from . import clone
 from . import components
@@ -14,14 +15,7 @@ from . import shell
 from . import uninstall
 from . import update
 from . import upgrade
-
-
-class CustomArgumentParser(argparse.ArgumentParser):
-    def __init__(self, handler=None, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        if not handler:
-            raise ValueError("Please provide a command handler")
-        self.handler = handler
+from . import binary_archives
 
 
 main_parser = argparse.ArgumentParser()
@@ -37,6 +31,7 @@ main_subparsers = main_parser.add_subparsers(
     description="Available subcommands. Use <subcommand> --help",
     dest="command_name",
     parser_class=CustomArgumentParser,
+    metavar="<subcommand>"
 )
 
 subcommands = [
@@ -54,6 +49,7 @@ subcommands = [
     ls,
     fix_binary_archives_symlinks,
     dumpconfig,
+    binary_archives
 ]
 
 for cmd in subcommands:


### PR DESCRIPTION
Introduces `orc binary-archives` command, with the following subcommands:

- `orc binary-archives clean`: deletes old binary archives
- `orc binary-archives fix-symlinks`: alias for `orc fix-binary-archives-symlinks`
- `orc binary-archives ls`: alias for `orc ls --binary-archives`

The `binary-archives clean` command uses the same logic used by the former orchestra; it removes archives which are not the target of any symlink.

For consistency I added the `cwd` parameter to all the subprocess helper functions instead of adding it only to `try_run_internal_script` and `get_script_output`.