### PR TITLE
Do not hardlink when merging tmproot into root

### DIFF
--- a/orchestra/actions/install.py
+++ b/orchestra/actions/install.py
@@ -353,7 +353,7 @@ class InstallAction(ActionForBuild):
         self._run_internal_script(patch_ndebug_script)
 
     def _merge(self):
-        copy_command = f'cp -farl "$TMP_ROOT/$ORCHESTRA_ROOT/." "$ORCHESTRA_ROOT"'
+        copy_command = f'cp -far --reflink=auto "$TMP_ROOT/$ORCHESTRA_ROOT/." "$ORCHESTRA_ROOT"'
         self._run_internal_script(copy_command)
 
     def _create_binary_archive(self):


### PR DESCRIPTION
Using -l is not supported on some environments like WSL2+NTFS. Adding --reflink=auto should keep good performance at least on systems suporting CoW.

This PR addresses https://github.com/revng/orchestra/issues/32