### PR TITLE
Fix `orc components` crash

### DIFF
--- a/orchestra/cmds/components.py
+++ b/orchestra/cmds/components.py
@@ -77,7 +77,7 @@ def handle_components(args):
                 continue
 
             branch, _ = component.clone.branch()
-            if not fnmatch(branch, args.branch):
+            if branch is None or not fnmatch(branch, args.branch):
                 continue
 
         # Filter by install status


### PR DESCRIPTION
This PR fixes a pretty obvious crash, caused by None being passed to `fnmatch`.