### PR TITLE
Add option to retry git LFS fetch

### DIFF
--- a/orchestra/actions/install.py
+++ b/orchestra/actions/install.py
@@ -165,7 +165,15 @@ class InstallAction(ActionForBuild):
         binary_archive_path = pathlib.Path(binary_archive_path)
         binary_archive_root = get_worktree_root(binary_archive_path)
         binary_archive_relative_path = binary_archive_path.relative_to(binary_archive_root)
-        lfs.fetch(binary_archive_root, include=[binary_archive_relative_path])
+        failures = 0
+        while True:
+            try:
+                lfs.fetch(binary_archive_root, include=[binary_archive_relative_path])
+                break
+            except OrchestraException as e:
+                failures += 1
+                if failures >= self.config.max_lfs_retries:
+                    raise e
 
     def _extract_binary_archive(self):
         if not self.binary_archive_exists():

--- a/orchestra/cmds/common.py
+++ b/orchestra/cmds/common.py
@@ -19,3 +19,6 @@ execution_group.add_argument(
     action="store_true",
     help="Do not execute actions, only print what would be done",
 )
+execution_group.add_argument(
+    "--lfs-retries", metavar="N", type=int, help="Retry fetching binary archives up to N times before giving up"
+)

--- a/orchestra/cmds/configure.py
+++ b/orchestra/cmds/configure.py
@@ -24,6 +24,7 @@ def handle_configure(args):
         force_from_source=args.from_source,
         use_config_cache=args.config_cache,
         run_tests=args.test,
+        max_lfs_retries=args.lfs_retries,
     )
 
     actions = set()

--- a/orchestra/cmds/install.py
+++ b/orchestra/cmds/install.py
@@ -34,6 +34,7 @@ def handle_install(args):
         no_merge=args.no_merge,
         keep_tmproot=args.keep_tmproot,
         run_tests=args.test,
+        max_lfs_retries=args.lfs_retries,
     )
 
     actions = set()

--- a/orchestra/cmds/upgrade.py
+++ b/orchestra/cmds/upgrade.py
@@ -20,6 +20,7 @@ def handle_upgrade(args):
         force_from_source=args.from_source,
         use_config_cache=args.config_cache,
         run_tests=args.test,
+        max_lfs_retries=args.lfs_retries,
     )
 
     install_actions = set()

--- a/orchestra/model/configuration/configuration.py
+++ b/orchestra/model/configuration/configuration.py
@@ -28,6 +28,7 @@ class Configuration:
         no_merge=False,
         keep_tmproot=False,
         run_tests=False,
+        max_lfs_retries=1,
     ):
         self.components: Dict[str, Component] = {}
 
@@ -39,6 +40,9 @@ class Configuration:
 
         # Enables creation of binary archives for all install actions that get run
         self.create_binary_archives = create_binary_archives
+
+        # Max lfs fetch attempts
+        self.max_lfs_retries = max_lfs_retries
 
         # Disables merging files into orchestra root after building
         # Useful for debugging a broken component without touching orchestra root


### PR DESCRIPTION
This PR adds a `--lfs-retries` option for install, configure and upgrade actions, which retries `git lfs fetch` up to N times in case of failure.