### PR TITLE
Misc fixes/improvements (GIT LFS, uninstall performance, fix setuptools invocation)

### DIFF
--- a/orchestra/cmds/common.py
+++ b/orchestra/cmds/common.py
@@ -1,5 +1,7 @@
 import argparse
 
+LFS_RETRIES_DEFAULT = 3
+
 build_options = argparse.ArgumentParser(add_help=False)
 build_group = build_options.add_argument_group(title="Build options")
 build_group.add_argument("--from-source", "-B", action="store_true", help="Build all components from source")
@@ -19,6 +21,11 @@ execution_group.add_argument(
     action="store_true",
     help="Do not execute actions, only print what would be done",
 )
+
 execution_group.add_argument(
-    "--lfs-retries", metavar="N", type=int, help="Retry fetching binary archives up to N times before giving up"
+    "--lfs-retries",
+    metavar="N",
+    type=int,
+    default=LFS_RETRIES_DEFAULT,
+    help=f"Retry fetching binary archives up to N times before giving up. Defaults to {LFS_RETRIES_DEFAULT}",
 )

--- a/orchestra/cmds/configure.py
+++ b/orchestra/cmds/configure.py
@@ -3,6 +3,7 @@ from loguru import logger
 from . import SubCommandParser
 from .common import execution_options, build_options
 from ..executor import Executor
+from ..gitutils.lfs import assert_lfs_installed
 from ..model.configuration import Configuration
 
 
@@ -26,6 +27,8 @@ def handle_configure(args):
         run_tests=args.test,
         max_lfs_retries=args.lfs_retries,
     )
+
+    assert_lfs_installed()
 
     actions = set()
     for component in args.components:

--- a/orchestra/cmds/install.py
+++ b/orchestra/cmds/install.py
@@ -3,6 +3,7 @@ from loguru import logger
 from . import SubCommandParser
 from .common import build_options, execution_options
 from ..executor import Executor
+from ..gitutils.lfs import assert_lfs_installed
 from ..model.configuration import Configuration
 
 
@@ -36,6 +37,8 @@ def handle_install(args):
         run_tests=args.test,
         max_lfs_retries=args.lfs_retries,
     )
+
+    assert_lfs_installed()
 
     actions = set()
     for component in args.components:

--- a/orchestra/cmds/update.py
+++ b/orchestra/cmds/update.py
@@ -8,6 +8,7 @@ from . import SubCommandParser
 from ..actions.util import run_internal_subprocess, try_run_internal_subprocess
 from ..exceptions import UserException
 from ..gitutils import is_root_of_git_repo
+from ..gitutils.lfs import assert_lfs_installed
 from ..model.configuration import Configuration
 
 
@@ -21,6 +22,8 @@ def handle_update(args):
     config = Configuration(use_config_cache=args.config_cache)
     failed_pulls = []
     failed_clones = []
+
+    assert_lfs_installed()
 
     if not args.no_config:
         logger.info("Updating orchestra configuration")

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
     author="Filippo Cremonese (rev.ng SRLs)",
     author_email="filippocremonese@rev.ng",
     url="https://github.com/revng/revng-orchestra",
-    packages=find_packages(),
+    packages=find_packages(include=["orchestra*"]),
     package_data={
         "orchestra": [
             "support/shell-home/.bashrc",

--- a/test/binary_archives/test_lfs.py
+++ b/test/binary_archives/test_lfs.py
@@ -1,0 +1,12 @@
+from ..orchestra_shim import OrchestraShim
+import orchestra.gitutils.lfs as lfs
+
+
+def test_lfs_proper_install_detection(orchestra: OrchestraShim, monkeypatch):
+    """Ensures that orchestra can detect when git lfs is not properly installed (i.e. ~/.gitconfig does not contain
+    the right filters).
+    This is done by overriding $HOME to a path which does not contain a .gitconfig file.
+    """
+    monkeypatch.setenv("HOME", "/tmp")
+    lfs._lfs_install_checked = False
+    orchestra("install", "-b", "component_C", should_fail=True)


### PR DESCRIPTION
This PR:
- addresses https://github.com/revng/revng-orchestra/issues/37, by checking that `git config --get filter.lfs.smudge` does not return non-zero, which should suffice in establishing that the global git LFS filters have been installed.
- sets the default number of retries on git-lfs failures
- drastically improves uninstall performance (~140x improvement on llvm-documentation uninstall time) 
- fixes setuptools `find_packages` invocation to limit it only to `orchestra` (and avoid installing the `test` package)