### PR TITLE
Add `--discard-build-directories` option to `orc install` and `--all` to `orc clean`

### DIFF
--- a/orchestra/actions/install.py
+++ b/orchestra/actions/install.py
@@ -46,6 +46,7 @@ class InstallAction(ActionForBuild):
         no_merge=False,
         keep_tmproot=False,
         run_tests=False,
+        discard_build_directories=False,
     ):
         assert (
             allow_build or allow_binary_archive
@@ -64,6 +65,7 @@ class InstallAction(ActionForBuild):
         self.no_merge = no_merge
         self.keep_tmproot = keep_tmproot
         self.run_tests = run_tests
+        self.discard_build_directories = discard_build_directories
 
     def _run(self, explicitly_requested=False):
         tmp_root = self.environment["TMP_ROOT"]
@@ -117,6 +119,10 @@ class InstallAction(ActionForBuild):
         if not self.keep_tmproot:
             logger.debug("Cleaning up tmproot")
             self._cleanup_tmproot()
+
+        if self.discard_build_directories:
+            logger.debug("Discarding build directory")
+            self._discard_build_directory()
 
     def _update_metadata(self, file_list, install_time, source, set_manually_insalled):
         # Save installed file list (.idx)
@@ -485,6 +491,9 @@ class InstallAction(ActionForBuild):
 
     def _cleanup_tmproot(self):
         shutil.rmtree(self.tmp_root, ignore_errors=True)
+
+    def _discard_build_directory(self):
+        shutil.rmtree(self.build_dir, ignore_errors=True)
 
     @property
     def _binary_archive_repo_name(self):

--- a/orchestra/actions/install.py
+++ b/orchestra/actions/install.py
@@ -1,6 +1,7 @@
 import glob
 import os
 import pathlib
+import shutil
 import stat
 import time
 from collections import OrderedDict, defaultdict
@@ -483,7 +484,7 @@ class InstallAction(ActionForBuild):
         return paths
 
     def _cleanup_tmproot(self):
-        self._run_internal_script('rm -rf "$TMP_ROOT"')
+        shutil.rmtree(self.tmp_root, ignore_errors=True)
 
     @property
     def _binary_archive_repo_name(self):

--- a/orchestra/cmds/clean.py
+++ b/orchestra/cmds/clean.py
@@ -14,21 +14,43 @@ def install_subcommand(sub_argparser: SubCommandParser):
         help="Remove build/source directories",
         parents=[execution_options],
     )
-    cmd_parser.add_argument("components", nargs="+", help="Name of the components to clean")
+    cmd_parser.add_argument("components", nargs="*", help="Name of the components to clean")
     cmd_parser.add_argument("--include-sources", "-s", action="store_true", help="Also delete source dir")
+    cmd_parser.add_argument("--all", action="store_true", help="Clean directories for all components")
+
+
+def clean_all(config: Configuration, args):
+    builds_dir = config.builds_dir
+    logger.info(f"Cleaning builds dir {builds_dir}")
+
+    if not args.pretend:
+        shutil.rmtree(builds_dir, ignore_errors=True)
+
+    if args.include_sources:
+        sources_dir = config.sources_dir
+        logger.info(f"Cleaning sources dir {sources_dir}")
+        if not args.pretend:
+            shutil.rmtree(sources_dir, ignore_errors=True)
 
 
 def handle_clean(args):
     config = Configuration(use_config_cache=args.config_cache)
 
-    builds = []
+    if bool(args.components) + bool(args.all) != 1:
+        logger.error("--all implies all components, do not specify any of them")
+        return 1
+
+    if args.all:
+        return clean_all(config, args)
+
+    builds = set()
     for component_name in args.components:
         build = config.get_build(component_name)
         if not build:
             suggested_component_name = config.get_suggested_component_name(component_name)
             logger.error(f"Component {component_name} not found! Did you mean {suggested_component_name}?")
             return 1
-        builds.append(build)
+        builds.add(build)
 
     for build in builds:
         build_dir = build.install.environment["BUILD_DIR"]

--- a/orchestra/cmds/common.py
+++ b/orchestra/cmds/common.py
@@ -11,6 +11,12 @@ build_group.add_argument(
     action="store_true",
     help="Build if binary archives are not available",
 )
+build_group.add_argument(
+    "--discard-build-directories",
+    action="store_true",
+    help="Discards build directories of the involved components after a successful build. Previously existing build "
+    "directories are used and then deleted. Use `orc clean` to remove them in advance.",
+)
 build_group.add_argument("--test", action="store_true", help="Run the test suite after building")
 
 execution_options = argparse.ArgumentParser(add_help=False)

--- a/orchestra/cmds/configure.py
+++ b/orchestra/cmds/configure.py
@@ -26,6 +26,7 @@ def handle_configure(args):
         use_config_cache=args.config_cache,
         run_tests=args.test,
         max_lfs_retries=args.lfs_retries,
+        discard_build_directories=args.discard_build_directories,
     )
 
     assert_lfs_installed()

--- a/orchestra/cmds/install.py
+++ b/orchestra/cmds/install.py
@@ -36,6 +36,7 @@ def handle_install(args):
         keep_tmproot=args.keep_tmproot,
         run_tests=args.test,
         max_lfs_retries=args.lfs_retries,
+        discard_build_directories=args.discard_build_directories,
     )
 
     assert_lfs_installed()

--- a/orchestra/cmds/upgrade.py
+++ b/orchestra/cmds/upgrade.py
@@ -21,6 +21,7 @@ def handle_upgrade(args):
         use_config_cache=args.config_cache,
         run_tests=args.test,
         max_lfs_retries=args.lfs_retries,
+        discard_build_directories=args.discard_build_directories,
     )
 
     install_actions = set()

--- a/orchestra/model/build.py
+++ b/orchestra/model/build.py
@@ -42,6 +42,7 @@ class Build:
             no_merge=configuration.no_merge,
             keep_tmproot=configuration.keep_tmproot,
             run_tests=configuration.run_tests,
+            discard_build_directories=configuration.discard_build_directories,
         )
 
         # Dependency names are needed for resolving them to the actual Actions and to compute the build hash

--- a/orchestra/model/configuration/configuration.py
+++ b/orchestra/model/configuration/configuration.py
@@ -31,6 +31,7 @@ class Configuration:
         no_merge=False,
         keep_tmproot=False,
         run_tests=False,
+        discard_build_directories=False,
         max_lfs_retries=1,
     ):
         self.components: Dict[str, Component] = {}
@@ -56,6 +57,9 @@ class Configuration:
 
         # Enables tests when building components from source
         self.run_tests = run_tests
+
+        # Discard build directories after a successful build
+        self.discard_build_directories = discard_build_directories
 
         self.orchestra_dotdir = locate_orchestra_dotdir(cwd=override_orchestra_dotdir)
         if not self.orchestra_dotdir:

--- a/test/install/test_install.py
+++ b/test/install/test_install.py
@@ -166,3 +166,9 @@ def test_keep_tmproot(orchestra: OrchestraShim):
     """Checks that the --keep-tmproot option works"""
     orchestra("install", "-b", "--keep-tmproot", "component_A")
     assert os.path.exists(orchestra.configuration.components["component_A"].default_build.install.tmp_root)
+
+
+def test_discard_build_directory(orchestra: OrchestraShim):
+    """Checks that the --keep-tmproot option works"""
+    orchestra("install", "-b", "--keep-tmproot", "--discard-build-directories", "component_A")
+    assert not os.path.exists(orchestra.configuration.components["component_A"].default_build.install.build_dir)


### PR DESCRIPTION
Adds a `--discard-build-directories` to `orc install` which discards the build directory of every built component after it is built successfully.

Also adds a `--all` option to `orc clean` which can be used to clean all build (and optionally source) directories with a single command.

PS: the fist commit just replaces a shell out to `rm -rf` with a call to `shutil.rmtree`