### PR TITLE
Support non-branch git refs

### DIFF
--- a/orchestra/actions/clone.py
+++ b/orchestra/actions/clone.py
@@ -21,11 +21,15 @@ class CloneAction(ActionForComponent):
 
         script += 'git -C "$SOURCE_DIR" branch -m orchestra-temporary\n'
 
-        checkout_cmds = []
+        # Try fetching each remote ref and adding a local branch with the same name that can be checked out
+        fetch_cmds = []
         for branch in self.config.branches:
-            checkout_cmds.append(f'git -C "$SOURCE_DIR" checkout -b "{branch}" "origin/{branch}"')
-        checkout_cmds.append("true")
-        script += " || \\\n  ".join(checkout_cmds)
+            fetch_cmds.append(
+                f'git -C "$SOURCE_DIR" fetch origin "{branch}:{branch}" && git -C "$SOURCE_DIR" checkout "{branch}"'
+            )
+        fetch_cmds.append("true")
+
+        script += " || \\\n  ".join(fetch_cmds)
         return script
 
     def is_satisfied(self):

--- a/test/ls_remote/test_ls_remote.py
+++ b/test/ls_remote/test_ls_remote.py
@@ -1,5 +1,7 @@
-from ..utils import git
+import os
+
 from ..conftest import OrchestraShim
+from ..utils import git
 
 
 def test_ls_remote_with_local_clone(orchestra: OrchestraShim):
@@ -34,4 +36,35 @@ def test_ls_remote_without_local_clone(orchestra: OrchestraShim):
     current_branch_name = git.run(remote_repo_path, "name-rev", "--name-only", "HEAD").strip()
 
     assert component.branch() == current_branch_name
+    assert component.commit() == current_commit
+
+
+def _make_remote_ref_non_branch(orchestra: OrchestraShim, component: str):
+    component_repo_path = os.path.join(orchestra.default_remote_base_url, component)
+    git.run(component_repo_path, "branch", "-m", "not_master")
+    git.run(component_repo_path, "update-ref", "refs/master", "HEAD")
+
+
+def test_ls_remote_non_branch_remote_ref_with_local_clone(orchestra: OrchestraShim):
+    """Checks that orchestra correctly reads the remote ref and commit hash when there is a local clone of the sources"""
+    _make_remote_ref_non_branch(orchestra, "component_A")
+    test_ls_remote_with_local_clone(orchestra)
+
+
+def test_ls_remote_non_branch_remote_ref_without_local_clone(orchestra: OrchestraShim):
+    """Checks that orchestra correctly reads the remote ref and commit hash when there is not a local clone of the
+    sources
+    """
+    _make_remote_ref_non_branch(orchestra, "component_A")
+
+    orchestra("update")
+
+    component = orchestra.configuration.components["component_A"]
+    remote_repo_path = orchestra.default_remote_base_url / "component_A"
+
+    current_commit = git.rev_parse(remote_repo_path)
+
+    # name-rev will always prefer the branch reference, orchestra will always prefer the configured ref name. Orchestra
+    # is right in this case so the name needs to be hardcoded.
+    assert component.branch() == "master"
     assert component.commit() == current_commit


### PR DESCRIPTION
This PR adds support for non-branch refs to orchestra.

~~The `branches` config option has been renamed to `refs`~~ (undone)

If the `branches` config option contains a remote reference that is not a branch, a new branch with the same name is created in the local repository and set to track the remote ref.