### PR TITLE
orc shell: exec rather than invoking subprocess

### DIFF
--- a/orchestra/actions/graph_util.py
+++ b/orchestra/actions/graph_util.py
@@ -27,4 +27,3 @@ def assign_style(graph):
             "fillcolor": color,
         }
     nx.set_node_attributes(graph, styles)
-

--- a/orchestra/actions/util/__init__.py
+++ b/orchestra/actions/util/__init__.py
@@ -1,10 +1,13 @@
 from collections import OrderedDict
+from subprocess import CompletedProcess
+from typing import NoReturn
 
 from .impl import _get_script_output
 from .impl import _get_subprocess_output
 from .impl import _run_internal_script
 from .impl import _run_internal_subprocess
 from .impl import _run_user_script
+from .impl import _run_script, _exec_script
 
 
 def run_internal_script(script, environment: OrderedDict = None, cwd=None):
@@ -35,6 +38,45 @@ def run_user_script(script, environment: OrderedDict = None, cwd=None):
     :param cwd: if not None, the command is executed in the specified path
     """
     _run_user_script(script, environment=environment, check_returncode=True, cwd=cwd)
+
+
+def run_script(
+    script,
+    environment: OrderedDict = None,
+    strict_flags=True,
+    cwd=None,
+    loglevel="INFO",
+    stdout=None,
+    stderr=None,
+) -> CompletedProcess:
+    """Helper for running shell scripts.
+    :param script: the script to run
+    :param environment: will be exported at the beginning of the script
+    :param strict_flags: if True, a prelude is prepended to the script to help catch errors
+    :param cwd: if not None, the command is executed in the specified path
+    :param loglevel: log debug informations at this level
+    :param stdout: passed as the "stdout" parameter to subprocess.run
+    :param stderr: passed as the "stderr" parameter to subprocess.run
+    :return: a subprocess.CompletedProcess instance
+    """
+    return _run_script(script, environment, strict_flags, cwd, loglevel, stdout, stderr)
+
+
+def exec_script(
+    script,
+    environment: OrderedDict = None,
+    strict_flags=True,
+    cwd=None,
+    loglevel="INFO",
+) -> NoReturn:
+    """Helper for exec-ing into a shell scripts.
+    :param script: the script to run
+    :param environment: will be exported at the beginning of the script
+    :param strict_flags: if True, a prelude is prepended to the script to help catch errors
+    :param cwd: if not None, the command is executed in the specified path
+    :param loglevel: log debug informations at this level
+    """
+    _exec_script(script, environment, strict_flags, cwd, loglevel)
 
 
 def get_script_output(script, environment: OrderedDict = None, decode_as="utf-8", cwd=None):

--- a/orchestra/cmds/clone.py
+++ b/orchestra/cmds/clone.py
@@ -34,6 +34,7 @@ def handle_clone(args):
         actions.add(build.component.clone)
 
     from ..executor import Executor
+
     executor = Executor(actions, no_force=args.no_force, pretend=args.pretend)
     failed = executor.run()
     exitcode = 1 if failed else 0

--- a/orchestra/cmds/configure.py
+++ b/orchestra/cmds/configure.py
@@ -42,6 +42,7 @@ def handle_configure(args):
         actions.add(build.configure)
 
     from ..executor import Executor
+
     executor = Executor(actions, no_deps=args.no_deps, no_force=args.no_force, pretend=args.pretend)
 
     failed = executor.run()

--- a/orchestra/cmds/graph.py
+++ b/orchestra/cmds/graph.py
@@ -79,6 +79,7 @@ def handle_graph(args):
                 actions.add(component.default_build.install)
 
     from ..executor import Executor
+
     executor = Executor(actions, no_force=args.no_force)
 
     if not args.solved:
@@ -92,8 +93,10 @@ def handle_graph(args):
         )
     if not args.no_color:
         from ..actions.graph_util import assign_style
+
         assign_style(graph)
     import networkx as nx
+
     graphviz_format = nx.nx_pydot.to_pydot(graph)
     graphviz_format.set_splines("ortho")
     graphviz_format.set_node_defaults(shape="box")

--- a/orchestra/cmds/install.py
+++ b/orchestra/cmds/install.py
@@ -77,6 +77,7 @@ def handle_install(args):
                 uninstall(component_to_uninstall.name, config)
 
     from ..executor import Executor
+
     for action in actions:
         executor = Executor([action], no_deps=args.no_deps, no_force=args.no_force, pretend=args.pretend)
         failed = executor.run()

--- a/orchestra/cmds/shell.py
+++ b/orchestra/cmds/shell.py
@@ -1,14 +1,14 @@
 import argparse
 import os
-import os.path
 import shlex
 from textwrap import dedent
+from typing import Union, NoReturn
 
 from loguru import logger
 
 from . import SubCommandParser
 from ..actions.util import get_script_output
-from ..actions.util.impl import _run_script
+from ..actions.util import exec_script
 from ..model.configuration import Configuration
 from ..exceptions import UserException
 
@@ -23,7 +23,7 @@ def install_subcommand(sub_argparser: SubCommandParser):
     cmd_parser.add_argument("command", nargs=argparse.REMAINDER)
 
 
-def handle_shell(args):
+def handle_shell(args) -> Union[NoReturn, int]:
     config = Configuration(use_config_cache=args.config_cache)
     command = args.command
 
@@ -46,14 +46,7 @@ def handle_shell(args):
 
     if command:
         script_to_run = " ".join(shlex.quote(c) for c in command)
-        p = _run_script(
-            script_to_run,
-            environment=env,
-            strict_flags=False,
-            cwd=cd_to,
-            loglevel="DEBUG",
-        )
-        return p.returncode
+        exec_script(script_to_run, environment=env, strict_flags=False, cwd=cd_to, loglevel="DEBUG")
 
     user_shell = get_script_output("getent passwd $(whoami) | cut -d: -f7").strip()
 
@@ -65,5 +58,5 @@ def handle_shell(args):
     env["HOME"] = os.path.join(os.path.dirname(__file__), "..", "support", "shell-home")
     env["PS1_PREFIX"] = ps1_prefix
     script = dedent(f"exec {user_shell}")
-    result = _run_script(script, environment=env, loglevel="DEBUG", cwd=cd_to)
-    return result.returncode
+    exec_script(script, environment=env, loglevel="DEBUG", cwd=cd_to)
+    return 0  # This will never be reached in a normal execution, needed for tests

--- a/orchestra/cmds/upgrade.py
+++ b/orchestra/cmds/upgrade.py
@@ -36,6 +36,7 @@ def handle_upgrade(args):
     args.keep_tmproot = False
     args.no_merge = False
     from ..executor import Executor
+
     executor = Executor(install_actions, no_force=True, pretend=args.pretend)
     failed = executor.run()
     exitcode = 1 if failed else 0

--- a/orchestra/util.py
+++ b/orchestra/util.py
@@ -2,6 +2,7 @@ import os
 import re
 import sys
 from collections import OrderedDict
+from typing import Mapping
 
 from .exceptions import UserException
 
@@ -13,7 +14,7 @@ def parse_component_name(component_spec):
     return component_name, build_name
 
 
-def export_environment(variables: OrderedDict):
+def export_environment(variables: Mapping):
     env = ""
     for var, val in variables.items():
         if var.startswith("-"):

--- a/test/commands/test_shell.py
+++ b/test/commands/test_shell.py
@@ -1,7 +1,15 @@
 from ..orchestra_shim import OrchestraShim
+from ..fork_shim import ForkShim
 
 
-def test_shell(orchestra: OrchestraShim):
+def test_shell(orchestra: OrchestraShim, capsys):
     """Checks that `orchestra shell <cmd>` works"""
-    orchestra("shell", "echo", "Working")
-    orchestra("shell", "exit", "1", should_fail=True)
+    with ForkShim() as shim:
+        orchestra("shell", "echo", "Working")
+        run = shim.get_last_execution()
+        assert run.returncode == 0
+        assert run.stdout == b"Working\n"
+
+        orchestra("shell", "exit", "1")
+        run = shim.get_last_execution()
+        assert run.returncode == 1

--- a/test/configuration/environment/test_environment.py
+++ b/test/configuration/environment/test_environment.py
@@ -1,6 +1,7 @@
 from textwrap import dedent
 
 from ...orchestra_shim import OrchestraShim
+from ...fork_shim import ForkShim
 
 # Mapping from the name of a property in Configuration to the corresponding environment variable
 configuration_property_name_to_environment = {
@@ -205,7 +206,9 @@ def test_shell_environment(orchestra: OrchestraShim, monkeypatch):
     config = orchestra.configuration
 
     # Check global variables have expected value
-    orchestra("shell", "bash", "-c", global_variables_check_script.format(config=config))
+    with ForkShim() as shim:
+        orchestra("shell", "bash", "-c", global_variables_check_script.format(config=config))
+        assert shim.get_last_execution().returncode == 0
 
     # Check the user config can set/unset variables
     with monkeypatch.context() as m:

--- a/test/fork_shim.py
+++ b/test/fork_shim.py
@@ -1,0 +1,30 @@
+from subprocess import run, PIPE, CompletedProcess
+from typing import Optional
+from unittest.mock import patch
+
+
+class ForkShim:
+    def __init__(self):
+        self.last_execution: Optional[CompletedProcess] = None
+
+    def __enter__(self):
+        self.patch = patch("orchestra.actions.util.impl.os").__enter__()
+        self.patch.fork = lambda: 1
+        self.patch.execvpe = self.fake_execvpe
+        return self
+
+    def __exit__(self, *args):
+        self.patch.__exit__(self, *args)
+
+    def fake_execvpe(self, file, args, env):
+        assert file == args[0]
+        # when running orc shell in tests, the handler is called twice
+        # first with the right arguments and then with no arguments at all
+        last_line = args[-1].splitlines()[-1]
+        if last_line.startswith("exec"):
+            return
+        self.last_execution = run(args, stdout=PIPE, stderr=PIPE)
+
+    def get_last_execution(self) -> CompletedProcess:
+        assert self.last_execution is not None
+        return self.last_execution


### PR DESCRIPTION
This commit does 2 things:
* Introduces an additional parameter to `_run_script` called `exec_`, if set to true it will make the script be exec'ed instead of running it in a subprocess
* Makes use of the change above in the subcommand `orc shell` that from now on will exec the target executable rather than invoke a subshell, this fixes a few problems with terminal and signal handling.

I've also tweaked the typing annotations in the affected functions.