### PR TITLE
locate_orchestra_dotdir: use ORCHESTRA_DOTDIR

### DIFF
--- a/orchestra/model/configuration/configuration.py
+++ b/orchestra/model/configuration/configuration.py
@@ -315,6 +315,9 @@ class Configuration:
 
 
 def locate_orchestra_dotdir(cwd=None):
+    if "ORCHESTRA_DOTDIR" in os.environ:
+        return os.environ["ORCHESTRA_DOTDIR"]
+
     if cwd is None:
         if globals.orchestra_dotdir is not None:
             cwd = globals.orchestra_dotdir


### PR DESCRIPTION
if orchestra is called within orchestra (e.g. within a build script) short-circuit dotdir selection to the path set by ORCHESTRA_DOTDIR