### PR TITLE
Increase context around diffs

### DIFF
--- a/orchestra/exceptions.py
+++ b/orchestra/exceptions.py
@@ -224,7 +224,8 @@ class BinaryArchiveNotFoundException(UserException):
                 _, output = orchestra.actions.util.try_get_subprocess_output(
                     [
                         "diff",
-                        "-u",
+                        "-U",
+                        "8",
                         color,
                         str(available_hash_material_path),
                         f.name,


### PR DESCRIPTION
The new value is picked to ensure that whenever we have a commit hash mismatch the diff also shows the offending repository in the error message, easing troubleshooting.